### PR TITLE
adding ratelimit and fixing common urls

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ Django==3.0.8
 Bio==0.1.0
 django_mptt==0.10.0
 django-ratelimit==3.0.0
+django-extensions==3.0.2
 sendgrid==6.4.3
 biopython==1.77

--- a/yeastphenome/apps/common/templates/base/head.html
+++ b/yeastphenome/apps/common/templates/base/head.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">

--- a/yeastphenome/apps/common/templates/base/navbar.html
+++ b/yeastphenome/apps/common/templates/base/navbar.html
@@ -10,7 +10,7 @@
                 <span class="sr-only">Sections</span>
                 <span class="glyphicon glyphicon-menu-hamburger"></span>
             </button>
-            <a class="navbar-brand" href="{% url 'index' %}">{{ SITE_NAME }} (<em>beta</em>)</a>
+            <a class="navbar-brand" href="{% url 'common:index' %}">{{ SITE_NAME }} (<em>beta</em>)</a>
         </div>
 
         <ul class="collapse navbar-collapse nav navbar-nav" id="nb-sections">
@@ -18,7 +18,7 @@
             <li {% if 'datasets' == active %} class="active" {% endif %} ><a href="{% url 'datasets:index' %}">Datasets</a></li>
             <li {% if 'phenotypes' == active %} class="active" {% endif %} ><a href="{% url 'phenotypes:index' %}">Phenotypes</a></li>
             <li {% if 'conditions' == active %} class="active" {% endif %} ><a href="{% url 'conditions:index' %}">Experimental conditions</a></li>
-            <li {% if 'about' == active %} class="active" {% endif %} ><a href="{% url 'about' %}">About</a></li>
+            <li {% if 'about' == active %} class="active" {% endif %} ><a href="{% url 'common:about' %}">About</a></li>
             <li {% if 'contributors' == active %} class="active" {% endif %} ><a href="{% url 'contributors' %}">Contributors</a></li>
         </ul>
 

--- a/yeastphenome/apps/common/templates/yeastphenome/index.html
+++ b/yeastphenome/apps/common/templates/yeastphenome/index.html
@@ -26,7 +26,7 @@
 
                 <p>Our goal is to collect, organize and share in a standardized format all phenotypic screens of the <em>Saccharomyces cerevisiae</em> deletion collection.</p>
 
-                <p><a class="btn btn-primary btn-lg" href="{% url 'about' %}" role="button">Learn more</a></p>
+                <p><a class="btn btn-primary btn-lg" href="{% url 'common:about' %}" role="button">Learn more</a></p>
 
             </div>
 

--- a/yeastphenome/apps/common/views.py
+++ b/yeastphenome/apps/common/views.py
@@ -11,6 +11,12 @@ from yeastphenome.apps.conditions.models import ConditionSet, ConditionType
 from yeastphenome.apps.phenotypes.models import Phenotype
 from yeastphenome.apps.datasets.models import Dataset
 
+from ratelimit.decorators import ratelimit
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
+
 
 def get_latest_stats():
     """Return number of papers, phenotypes, and datasets to display in the index
@@ -262,6 +268,7 @@ def get_latest_stats():
     return context
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def index(request):
 
     form = SearchForm()
@@ -272,6 +279,7 @@ def index(request):
     return render(request, "yeastphenome/index.html", context)
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def about(request):
 
     context = get_latest_stats()

--- a/yeastphenome/apps/conditions/views.py
+++ b/yeastphenome/apps/conditions/views.py
@@ -15,7 +15,15 @@ from yeastphenome.apps.common.forms import SearchForm
 
 from libchebipy import ChebiEntity
 
+from ratelimit.mixins import RatelimitMixin
+from ratelimit.decorators import ratelimit
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
 
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def index(request):
 
     if "q" in request.GET:
@@ -66,9 +74,12 @@ def index(request):
         return render(request, "conditions/index.html", {"form": form,})
 
 
-class ConditiontypeDetailView(generic.DetailView):
+class ConditiontypeDetailView(generic.DetailView, RatelimitMixin):
     model = ConditionType
     template_name = "conditions/detail.html"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_context_data(self, **kwargs):
         context = super(ConditiontypeDetailView, self).get_context_data(**kwargs)
@@ -79,6 +90,7 @@ class ConditiontypeDetailView(generic.DetailView):
         return context
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def conditionclass(request, class_id):
     class_entity = ChebiEntity("CHEBI:" + str(class_id))
     class_name = class_entity.get_name()
@@ -110,9 +122,12 @@ def conditionclass(request, class_id):
     )
 
 
-class MediumDetailView(generic.DetailView):
+class MediumDetailView(generic.DetailView, RatelimitMixin):
     model = Medium
     template_name = "conditions/conditionset_medium_detail.html"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_context_data(self, **kwargs):
         context = super(MediumDetailView, self).get_context_data(**kwargs)
@@ -123,9 +138,12 @@ class MediumDetailView(generic.DetailView):
         return context
 
 
-class ConditionSetDetailView(generic.DetailView):
+class ConditionSetDetailView(generic.DetailView, RatelimitMixin):
     model = ConditionSet
     template_name = "conditions/conditionset_medium_detail.html"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_context_data(self, **kwargs):
         context = super(ConditionSetDetailView, self).get_context_data(**kwargs)

--- a/yeastphenome/apps/datasets/views.py
+++ b/yeastphenome/apps/datasets/views.py
@@ -11,19 +11,31 @@ from yeastphenome.apps.phenotypes.models import Observable2
 
 from libchebipy import ChebiEntity
 
+from ratelimit.mixins import RatelimitMixin
+from ratelimit.decorators import ratelimit
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
 
-class DatasetDetailView(generic.DetailView):
+
+class DatasetDetailView(generic.DetailView, RatelimitMixin):
     model = Dataset
     template_name = "datasets/detail.html"
     context_object_name = "dataset"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def index(request):
 
     context = {}
     return render(request, "datasets/index.html", context)
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def tag(request, id):
 
     t = get_object_or_404(Tag, pk=id)
@@ -46,6 +58,7 @@ def tag(request, id):
     )
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def datasets_growth(request):
 
     class_description = (
@@ -75,6 +88,7 @@ def datasets_growth(request):
     )
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def datasets_human(request):
 
     class_description = (
@@ -101,6 +115,7 @@ def datasets_human(request):
     )
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def download_all(request):
 
     datasets = (
@@ -126,6 +141,7 @@ def download_all(request):
     return response
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def download(request):
 
     file_header = ""
@@ -181,6 +197,7 @@ def download(request):
     return response
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def data(request, domain, id):
 
     file_header = ""

--- a/yeastphenome/apps/papers/templates/papers/contributors.html
+++ b/yeastphenome/apps/papers/templates/papers/contributors.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}<!DOCTYPE html>
+{% load static %}<!DOCTYPE html>
 <html lang="en"><head>
 {% include "base/head.html" with JavaScript='tablesorter' %}
 <title>Contributors / {{ SITE_NAME }}</title>

--- a/yeastphenome/apps/papers/views.py
+++ b/yeastphenome/apps/papers/views.py
@@ -12,7 +12,15 @@ from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.conf import settings
 
+from ratelimit.mixins import RatelimitMixin
+from ratelimit.decorators import ratelimit
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
 
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def paper_list_view(request):
 
     queryset = Paper.objects.all()
@@ -54,9 +62,12 @@ def paper_list_view(request):
     return render(request, "papers/index.html", {"papers_list": queryset, "q": q,})
 
 
-class PaperDetailView(generic.DetailView):
+class PaperDetailView(generic.DetailView, RatelimitMixin):
     model = Paper
     template_name = "papers/detail.html"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_context_data(self, **kwargs):
         context = super(PaperDetailView, self).get_context_data(**kwargs)
@@ -144,10 +155,13 @@ class PaperDetailView(generic.DetailView):
         return context
 
 
-class ContributorsListView(generic.ListView):
+class ContributorsListView(generic.ListView, RatelimitMixin):
     model = Paper
     template_name = "papers/contributors.html"
     context_object_name = "papers_list"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_queryset(self):
         return Paper.objects.filter(
@@ -156,6 +170,7 @@ class ContributorsListView(generic.ListView):
         ).distinct()
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def download_zip(request, paper_id, paper_pmid):
 
     p = get_object_or_404(Paper, pk=paper_id)
@@ -183,6 +198,7 @@ def download_zip(request, paper_id, paper_pmid):
     return response
 
 
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
 def paper_datasets(request, paper_id):
     p = get_object_or_404(Paper, pk=paper_id)
 

--- a/yeastphenome/apps/phenotypes/templates/phenotypes/detail.html
+++ b/yeastphenome/apps/phenotypes/templates/phenotypes/detail.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}{% load string_multiply %}
+{% load static %}{% load string_multiply %}
 <!DOCTYPE html>
 <html lang="en">
 <head>

--- a/yeastphenome/apps/phenotypes/templates/phenotypes/stats.html
+++ b/yeastphenome/apps/phenotypes/templates/phenotypes/stats.html
@@ -1,4 +1,4 @@
-{% load staticfiles %}
+{% load static %}
 <html>
 <head>
 <link rel="stylesheet" type="text/css" href="{% static 'papers/style.css' %}" />

--- a/yeastphenome/apps/phenotypes/views.py
+++ b/yeastphenome/apps/phenotypes/views.py
@@ -3,17 +3,29 @@ from django.conf import settings
 
 from yeastphenome.apps.phenotypes.models import Observable
 
+from ratelimit.mixins import RatelimitMixin
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
 
-class ObservableIndexView(generic.ListView):
+
+class ObservableIndexView(generic.ListView, RatelimitMixin):
     model = Observable
     template_name = "phenotypes/index.html"
     context_object_name = "observables"
     queryset = Observable.objects.order_by("name").all()
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
 
-class ObservableDetailView(generic.DetailView):
+class ObservableDetailView(generic.DetailView, RatelimitMixin):
     model = Observable
     template_name = "phenotypes/detail.html"
+    ratelimit_key = "ip"
+    ratelimit_rate = rl_rate
+    ratelimit_block = rl_block
 
     def get_context_data(self, **kwargs):
         context = super(ObservableDetailView, self).get_context_data(**kwargs)


### PR DESCRIPTION
updating the organization to have index/about and other common views under the common app will break previously used url references that dont have the prefix. This commit adds ratelimit along with fixing these references

Signed-off-by: vsoch <vsochat@stanford.edu>