### PR TITLE
Adding basic views for cart

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@ this punny bread:
 
 ## TODO
 
- - move everything over to GitHub org for yeastphenome.
  - add social media links (e.g., Twitter) for site metadata
  - remove observable2 and link in phenotype, mptt import
  - create "Add to cart" functionality for datasets

--- a/yeastphenome/apps/common/templates/base/navbar.html
+++ b/yeastphenome/apps/common/templates/base/navbar.html
@@ -20,6 +20,12 @@
             <li {% if 'conditions' == active %} class="active" {% endif %} ><a href="{% url 'conditions:index' %}">Experimental conditions</a></li>
             <li {% if 'about' == active %} class="active" {% endif %} ><a href="{% url 'common:about' %}">About</a></li>
             <li {% if 'contributors' == active %} class="active" {% endif %} ><a href="{% url 'contributors' %}">Contributors</a></li>
+            <li>
+               <a href="{% url 'common:view_cart' %}" class="nav-link waves-effect">
+               <i class="fa fa-shopping-cart" aria-hidden="true"></i>
+                    <span class="clearfix d-none d-sm-inline-block"></span>
+               </a>
+            </li>
         </ul>
 
         <div class="collapse navbar-collapse" id="nb-search">
@@ -29,6 +35,7 @@
                 </div>
                 <button type="submit" class="btn btn-default">Submit</button>
             </form>
+
         </div>
     </div>
 </nav>

--- a/yeastphenome/apps/common/templates/cart/view_cart.html
+++ b/yeastphenome/apps/common/templates/cart/view_cart.html
@@ -1,0 +1,131 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    {% include "base/head.html" %}
+    <title>{{ SITE_NAME }}</title>
+</head>
+
+<body>
+
+{% include "base/navbar.html" with active="" %}
+{% load humanize %}
+
+<div class="container-fluid">
+
+  {% include "messages/message.html" %}
+
+  <div class="row">
+    <h1>Datasets Download Cart</h1>
+    <div class="col-md-8 mb-4">
+        {% if datasets %}
+	<form action="{% url 'datasets:download' %}" method="GET" class="card-body">
+        <table id="papersTable" class="tablesorter table table-condensed table-hover" width="100%">
+        <thead>
+        <th>Paper</th>
+        <th>Phenotype</th>
+        <th>Condition</th>
+        <th>Medium</th>
+        <th>Collection</th>
+        <th>Tested mutants</th>
+        <th>Data</th>
+        <th>Details</th>
+        </thead>
+
+        <tbody>
+        {% for dataset in datasets %}<tr>
+            <input id="{{ dataset.id }}" type="hidden" name="{{ dataset.id }}">
+            <td class="col-md-2"><a href="{% url 'papers:detail' dataset.paper.id %}">{{ dataset.paper }}</a></td>
+            <td class="col-md-2">{{ dataset.phenotype.observable2.name }} {% if dataset.phenotype.reporter %} ({{ dataset.phenotype.reporter }}) {% endif %}</td>
+            <td class="col-md-1">{{ dataset.conditionset.display_name }}</td>
+            <td class="col-md-2">{{ dataset.medium.display_name }}</td>
+            <td class="col-md-1">{{ dataset.collection.shortname }}</td>
+
+            <td class="col-md-1">
+                {{ dataset.tested_space|safe }}
+            </td>
+
+            <td class="col-md-1">
+                {% if dataset.has_data_in_db %}
+                <span class="text-success available">{{ dataset.data_available|capfirst }}</span>
+                {% else %}
+                <span class="text-muted">{{ dataset.data_available|capfirst }}</span>
+                {% endif %}
+            </td>
+            <td>
+                <a href="{% url 'common:remove_from_cart' dataset.id "common:view_cart" %}"><button type="button" class="btn btn-danger btn-sm" style="width:100px">Remove</button></a>
+            </td>
+        </tr>{% endfor %}
+        </tbody>
+    </table>
+
+        <hr class="mb-4">
+        <button class="btn btn-primary btn-lg btn-block" type="submit">Download</button>
+        </form>
+        {% else %}
+          <p class="alert alert-info">You have no datasets in your cart. Why don't you <a href="{% url 'datasets:index' %}">browse to add some?</a></p>
+        {% endif %}
+    </div>
+     <div class="col-md-4 mb-4">
+
+    <div class="col-md-12 mb-4">
+    <h4 class="d-flex justify-content-between align-items-center mb-3">
+      <span class="text-muted">Download Metrics</span>
+      <span class="badge badge-secondary badge-pill">{{ datasets | length }}</span>
+    </h4>
+
+    <ul class="list-group mb-3 z-depth-1">
+    <li class="list-group-item d-flex justify-content-between lh-condensed">
+        <div>
+        <h6 class="my-0">1 x Metric 1</h6>
+        <small class="text-muted">This metric is this cool thing.</small>
+        </div>
+    </li>
+    <li class="list-group-item d-flex justify-content-between">
+        <span>Total Datasets</span>
+        <strong>{{ datasets | length }}</strong>
+    </li>
+    </ul>
+    <a href="{% url 'common:clear_cart' %}"><button class="btn btn-danger btn-lg">Clear Cart</button></a>
+
+    </div>
+   </div>
+
+    </div>
+  </main>
+
+    {% include "base/footer.html" %}
+
+<script>
+
+$("form").submit(function( event ) {
+
+  console.log("Form submit for dataset download")
+  var url = "#";
+
+  fetch(url).then(res => res.json())
+  .then(function(response) {
+    var response = JSON.stringify(response) 
+    console.log('Success:', response)
+
+    // On an error (order already submit, wrong user) don't send form
+    if (response['message'] == "error"){
+       event.preventDefault();
+    }
+  })
+  .catch(function(response) {
+     var response = JSON.stringify(response);
+     console.log("Error", response)
+     event.preventDefault();
+  })
+});
+
+
+</script>
+
+</div>
+
+{% include "base/ga.html" %}
+
+</body>
+
+</html>

--- a/yeastphenome/apps/common/templates/messages/message.html
+++ b/yeastphenome/apps/common/templates/messages/message.html
@@ -1,0 +1,12 @@
+<div class="row">
+    <div class="col-md-12">
+      {% for message in messages %}
+        <div class="alert alert-{{ message.tags }} alert-dismissible" role="alert">
+          {{ message }}
+          <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+            <span aria-hidden="true">&times;</span>
+          </button>
+        </div>
+        {% endfor %}
+    </div>
+</div>

--- a/yeastphenome/apps/common/urls.py
+++ b/yeastphenome/apps/common/urls.py
@@ -1,10 +1,18 @@
-from django.conf.urls import url
+from django.urls import path
 
 from . import views
 
 urlpatterns = [
-    url(r"^$", views.index, name="index"),
-    url(r"^about/$", views.about, name="about"),
+    path("", views.index, name="index"),
+    path("about/", views.about, name="about"),
+    path("cart/", views.view_cart, name="view_cart"),
+    path("cart/add/<str:dataset_id>/<str:next>", views.add_to_cart, name="add_to_cart"),
+    path(
+        "cart/remove/<str:dataset_id>/<str:next>",
+        views.remove_from_cart,
+        name="remove_from_cart",
+    ),
+    path("cart/clear/", views.clear_cart, name="clear_cart"),
 ]
 
 app_name = "common"

--- a/yeastphenome/apps/common/utils.py
+++ b/yeastphenome/apps/common/utils.py
@@ -1,0 +1,263 @@
+from django.db.models import Q, F, Count, Sum, Case, When
+from django.db import models
+
+import numpy as np
+
+
+from yeastphenome.apps.papers.models import Paper
+from yeastphenome.apps.conditions.models import ConditionSet, ConditionType
+from yeastphenome.apps.phenotypes.models import Phenotype
+from yeastphenome.apps.datasets.models import Dataset
+
+
+# Stats helper function
+
+
+def get_latest_stats():
+    """Return number of papers, phenotypes, and datasets to display in the index
+       view. If no entries are found, display counts of zero.
+    """
+    papers_queryset = Paper.objects.all()
+    phenotypes_queryset = Phenotype.objects.all()
+    conditions_queryset = ConditionSet.objects.all()
+    datasets_queryset = Dataset.objects.all()
+
+    # Total number of papers to process
+    f = Q(latest_data_status__status__is_valid=True)
+    papers_nr = papers_queryset.filter(f).count()
+
+    # Latest modified paper
+    updated_on = papers_queryset.latest().modified_on if papers_queryset else None
+
+    # Number of hopeless papers
+    f = Q(latest_data_status__status__name__in=["request abandoned", "not available"])
+    papers_hopeless_nr = papers_queryset.filter(f).count()
+
+    # Number of labs
+    f = Q(latest_data_status__status__name__in=["not relevant"])
+    labs_nr = papers_queryset.exclude(f).values("last_author").distinct().count()
+
+    # Number of papers processed and loaded
+    f = Q(latest_data_status__status__name__exact="loaded") & Q(
+        latest_tested_status__status__name__in=[
+            "loaded",
+            "request abandoned",
+            "not available",
+        ]
+    )
+    papers_queryset = papers_queryset.filter(f)
+    papers_processed_nr = papers_queryset.count()
+
+    # Number of phenotypes
+    f = Q(dataset__paper__in=papers_queryset)
+    phenotypes_nr = phenotypes_queryset.filter(f).distinct().count()
+
+    # Number of conditions
+    f = Q(dataset__paper__in=papers_queryset)
+    conditions_nr = conditions_queryset.filter(f).distinct().count()
+
+    # Number of datasets (total)
+    f = Q(paper__in=papers_queryset)
+    datasets_nr = datasets_queryset.filter(f).distinct().count()
+
+    # --- Conditions ---
+    conditiontypes_qs = ConditionType.objects.all()
+    top_conditiontypes = (
+        conditiontypes_qs.annotate(
+            nr_papers=Count("condition__conditionset__dataset__paper", distinct=True)
+        )
+        .annotate(
+            nr_datasets=Sum(
+                Case(
+                    When(
+                        condition__conditionset__dataset__data_available__shortname__in=[
+                            "q",
+                            "qofh",
+                            "d",
+                        ],
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=models.IntegerField(),
+                )
+            ),
+            nr_datasets_q=Sum(
+                Case(
+                    When(
+                        condition__conditionset__dataset__data_available__shortname="q",
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=models.IntegerField(),
+                )
+            ),
+            nr_datasets_d=Sum(
+                Case(
+                    When(
+                        condition__conditionset__dataset__data_available__shortname="d",
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=models.IntegerField(),
+                )
+            ),
+            nr_datasets_qofh=Sum(
+                Case(
+                    When(
+                        condition__conditionset__dataset__data_available__shortname="qofh",
+                        then=1,
+                    ),
+                    default=0,
+                    output_field=models.IntegerField(),
+                )
+            ),
+        )
+        .exclude(name__in=["standard", "time"])
+        .order_by("-nr_papers")
+    )
+
+    # top_conditiontypes_q = top_conditiontypes. \
+    #     annotate(nr_datasets_q=Count(condition__conditionset__dataset__paper__data_available__shortname='q'))
+
+    # --- Collections ----
+    f = Q(paper__in=papers_queryset)
+
+    c = Q(collection__shortname__in=["hap a"])
+    datasets_nr_hap_a = datasets_queryset.filter(f & c).distinct().count()
+    datasets_prc_hap_a = (
+        int(np.rint(100 * datasets_nr_hap_a / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    c = Q(collection__shortname__in=["hap alpha"])
+    datasets_nr_hap_alpha = datasets_queryset.filter(f & c).distinct().count()
+    datasets_prc_hap_alpha = (
+        int(np.rint(100 * datasets_nr_hap_alpha / datasets_nr))
+        if datasets_nr != 0
+        else 0
+    )
+
+    c = Q(collection__shortname__in=["hom"])
+    datasets_nr_hom = datasets_queryset.filter(f & c).distinct().count()
+    datasets_prc_hom = (
+        int(np.rint(100 * datasets_nr_hom / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    c = Q(collection__shortname__in=["het"])
+    datasets_nr_het = datasets_queryset.filter(f & c).distinct().count()
+    datasets_prc_het = (
+        int(np.rint(100 * datasets_nr_het / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    c = Q(
+        collection__shortname__in=[
+            "hap ?",
+            "hap a/hap alpha/hom",
+            "hap a/hap alpha",
+            "hap a/hom",
+            "hom/het?",
+            "hom/het",
+            "hap a/het",
+            "hap ?/hom/het",
+        ]
+    )
+    datasets_nr_mix = datasets_queryset.filter(f & c).distinct().count()
+    datasets_prc_mix = (
+        int(np.rint(100 * datasets_nr_mix / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    datasets_nr_collections_total = (
+        datasets_nr_hap_a
+        + datasets_nr_hap_alpha
+        + datasets_nr_hom
+        + datasets_nr_het
+        + datasets_nr_mix
+    )
+
+    # c = Q(collection__shortname__in=['hap a', 'hap alpha', 'hom', 'het', 'hap ?', 'hap a/hap alpha/hom',
+    #                                  'hap a/hap alpha', 'hap a/hom', 'hom/het?',
+    #                                  'hom/het', 'hap a/het', 'hap ?/hom/het'])
+    # missing = datasets_queryset.filter(f).exclude(c)
+
+    # --- Data types ---
+    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="q")
+    datasets_nr_q = datasets_queryset.filter(f).distinct().count()
+    datasets_prc_q = (
+        int(np.rint(100 * datasets_nr_q / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="qofh")
+    datasets_nr_qofh = datasets_queryset.filter(f).distinct().count()
+    datasets_prc_qofh = (
+        int(np.rint(100 * datasets_nr_qofh / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="d")
+    datasets_nr_d = datasets_queryset.filter(f).distinct().count()
+    datasets_prc_d = (
+        int(np.rint(100 * datasets_nr_d / datasets_nr)) if datasets_nr != 0 else 0
+    )
+
+    datasets_nr_data_available_total = datasets_nr_q + datasets_nr_qofh + datasets_nr_d
+
+    # Data recovery for haploid/homozygous diploid
+    f = Q(paper__in=papers_queryset)
+
+    g1 = Q(
+        data_measured__rank__lt=F("data_published__rank")
+    )  # datasets in need of data recovery
+    g2 = Q(
+        data_available__rank__lt=F("data_published__rank")
+    )  # datasets with recovered data
+
+    h1 = Q(tested_list_published=False)  # datasets in need of tested list recovery
+    h2 = Q(tested_list_published=False) & Q(
+        tested_source_id__isnull=False
+    )  # datasets with recovered tested list
+
+    fgh = f & (g2 | h2)  # all datasets with something recovered
+
+    datasets_nr_need_data = datasets_queryset.filter(f & g1).distinct().count()
+    datasets_nr_need_tested = datasets_queryset.filter(f & h1).distinct().count()
+
+    datasets_nr_recovered_all = datasets_queryset.filter(fgh).distinct().count()
+    datasets_nr_recovered_data = datasets_queryset.filter(f & g2).distinct().count()
+    datasets_nr_recovered_tested = datasets_queryset.filter(f & h2).distinct().count()
+
+    # Heterozygous
+
+    context = {
+        "papers_nr": papers_nr,
+        "papers_hopeless_nr": papers_hopeless_nr,
+        "labs_nr": labs_nr,
+        "papers_processed_nr": papers_processed_nr,
+        "phenotypes_nr": phenotypes_nr,
+        "conditions_nr": conditions_nr,
+        "datasets_nr": datasets_nr,
+        "datasets_nr_hap_a": datasets_nr_hap_a,
+        "datasets_prc_hap_a": datasets_prc_hap_a,
+        "datasets_nr_hap_alpha": datasets_nr_hap_alpha,
+        "datasets_prc_hap_alpha": datasets_prc_hap_alpha,
+        "datasets_nr_hom": datasets_nr_hom,
+        "datasets_prc_hom": datasets_prc_hom,
+        "datasets_nr_het": datasets_nr_het,
+        "datasets_prc_het": datasets_prc_het,
+        "datasets_nr_mix": datasets_nr_mix,
+        "datasets_prc_mix": datasets_prc_mix,
+        "datasets_nr_collections_total": datasets_nr_collections_total,
+        "datasets_nr_q": datasets_nr_q,
+        "datasets_prc_q": datasets_prc_q,
+        "datasets_nr_qofh": datasets_nr_qofh,
+        "datasets_prc_qofh": datasets_prc_qofh,
+        "datasets_nr_d": datasets_nr_d,
+        "datasets_prc_d": datasets_prc_d,
+        "datasets_nr_data_available_total": datasets_nr_data_available_total,
+        "datasets_nr_need_data": datasets_nr_need_data,
+        "datasets_nr_need_tested": datasets_nr_need_tested,
+        "datasets_nr_recovered_all": datasets_nr_recovered_all,
+        "datasets_nr_recovered_data": datasets_nr_recovered_data,
+        "datasets_nr_recovered_tested": datasets_nr_recovered_tested,
+        "top_conditiontypes": top_conditiontypes[:10],
+        "updated_on": updated_on,
+    }
+
+    return context

--- a/yeastphenome/apps/common/views.py
+++ b/yeastphenome/apps/common/views.py
@@ -1,14 +1,8 @@
-from django.shortcuts import render
-from django.db.models import Q, F, Count, Sum, Case, When
-from django.db import models
-
-import numpy as np
+from django.shortcuts import render, redirect
+from django.contrib import messages
 
 from yeastphenome.apps.common.forms import SearchForm
-
-from yeastphenome.apps.papers.models import Paper
-from yeastphenome.apps.conditions.models import ConditionSet, ConditionType
-from yeastphenome.apps.phenotypes.models import Phenotype
+from yeastphenome.apps.common.utils import get_latest_stats
 from yeastphenome.apps.datasets.models import Dataset
 
 from ratelimit.decorators import ratelimit
@@ -18,254 +12,72 @@ from yeastphenome.settings import (
 )
 
 
-def get_latest_stats():
-    """Return number of papers, phenotypes, and datasets to display in the index
-       view. If no entries are found, display counts of zero.
+# Cart Operations
+
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def add_to_cart(request, dataset_id, next=None):
+    """Add a dataset to the cart, if it exists.
     """
-    papers_queryset = Paper.objects.all()
-    phenotypes_queryset = Phenotype.objects.all()
-    conditions_queryset = ConditionSet.objects.all()
-    datasets_queryset = Dataset.objects.all()
-
-    # Total number of papers to process
-    f = Q(latest_data_status__status__is_valid=True)
-    papers_nr = papers_queryset.filter(f).count()
-
-    # Latest modified paper
-    updated_on = papers_queryset.latest().modified_on if papers_queryset else None
-
-    # Number of hopeless papers
-    f = Q(latest_data_status__status__name__in=["request abandoned", "not available"])
-    papers_hopeless_nr = papers_queryset.filter(f).count()
-
-    # Number of labs
-    f = Q(latest_data_status__status__name__in=["not relevant"])
-    labs_nr = papers_queryset.exclude(f).values("last_author").distinct().count()
-
-    # Number of papers processed and loaded
-    f = Q(latest_data_status__status__name__exact="loaded") & Q(
-        latest_tested_status__status__name__in=[
-            "loaded",
-            "request abandoned",
-            "not available",
-        ]
-    )
-    papers_queryset = papers_queryset.filter(f)
-    papers_processed_nr = papers_queryset.count()
-
-    # Number of phenotypes
-    f = Q(dataset__paper__in=papers_queryset)
-    phenotypes_nr = phenotypes_queryset.filter(f).distinct().count()
-
-    # Number of conditions
-    f = Q(dataset__paper__in=papers_queryset)
-    conditions_nr = conditions_queryset.filter(f).distinct().count()
-
-    # Number of datasets (total)
-    f = Q(paper__in=papers_queryset)
-    datasets_nr = datasets_queryset.filter(f).distinct().count()
-
-    # --- Conditions ---
-    conditiontypes_qs = ConditionType.objects.all()
-    top_conditiontypes = (
-        conditiontypes_qs.annotate(
-            nr_papers=Count("condition__conditionset__dataset__paper", distinct=True)
+    try:
+        dataset = Dataset.objects.get(id=dataset_id)
+        if "cart" not in request.session:
+            request.session["cart"] = []
+        if dataset.id not in request.session["cart"]:
+            request.session["cart"].append(dataset.id)
+        request.session.modified = True
+        messages.success(
+            request, "Dataset with id %s was added to your download cart." % dataset_id
         )
-        .annotate(
-            nr_datasets=Sum(
-                Case(
-                    When(
-                        condition__conditionset__dataset__data_available__shortname__in=[
-                            "q",
-                            "qofh",
-                            "d",
-                        ],
-                        then=1,
-                    ),
-                    default=0,
-                    output_field=models.IntegerField(),
-                )
-            ),
-            nr_datasets_q=Sum(
-                Case(
-                    When(
-                        condition__conditionset__dataset__data_available__shortname="q",
-                        then=1,
-                    ),
-                    default=0,
-                    output_field=models.IntegerField(),
-                )
-            ),
-            nr_datasets_d=Sum(
-                Case(
-                    When(
-                        condition__conditionset__dataset__data_available__shortname="d",
-                        then=1,
-                    ),
-                    default=0,
-                    output_field=models.IntegerField(),
-                )
-            ),
-            nr_datasets_qofh=Sum(
-                Case(
-                    When(
-                        condition__conditionset__dataset__data_available__shortname="qofh",
-                        then=1,
-                    ),
-                    default=0,
-                    output_field=models.IntegerField(),
-                )
-            ),
+    except:
+        messages.info(request, "Dataset with id %s does not exist" % dataset_id)
+
+    # Return to the same page the user was browsing
+    if next is not None:
+        return redirect(next)
+    return redirect("common:view_cart")
+
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def remove_from_cart(request, dataset_id, next=None):
+    """Remove a dataset from the cart, if it exists.
+    """
+    dataset_id = int(dataset_id)
+    if "cart" in request.session and dataset_id in request.session["cart"]:
+        request.session["cart"].pop(request.session["cart"].index(dataset_id))
+        request.session.modified = True
+        messages.success(
+            request,
+            "Dataset with id %s was removed from your download cart." % dataset_id,
         )
-        .exclude(name__in=["standard", "time"])
-        .order_by("-nr_papers")
-    )
+    else:
+        messages.info(request, "Dataset with id %s is not in your cart." % dataset_id)
 
-    # top_conditiontypes_q = top_conditiontypes. \
-    #     annotate(nr_datasets_q=Count(condition__conditionset__dataset__paper__data_available__shortname='q'))
+    # Return to the same page the user was browsing
+    if next is not None:
+        return redirect(next)
+    return redirect("common:view_cart")
 
-    # --- Collections ----
-    f = Q(paper__in=papers_queryset)
 
-    c = Q(collection__shortname__in=["hap a"])
-    datasets_nr_hap_a = datasets_queryset.filter(f & c).distinct().count()
-    datasets_prc_hap_a = (
-        int(np.rint(100 * datasets_nr_hap_a / datasets_nr)) if datasets_nr != 0 else 0
-    )
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def clear_cart(request):
+    """remove all datasets from the session cart. We don't add a message because
+       this view is only accessible from the View Cart page, and when it's cleared
+       the user is shown a message that there are no items in the cart.
+    """
+    if "cart" in request.session:
+        del request.session["cart"]
+    return redirect("common:view_cart")
 
-    c = Q(collection__shortname__in=["hap alpha"])
-    datasets_nr_hap_alpha = datasets_queryset.filter(f & c).distinct().count()
-    datasets_prc_hap_alpha = (
-        int(np.rint(100 * datasets_nr_hap_alpha / datasets_nr))
-        if datasets_nr != 0
-        else 0
-    )
 
-    c = Q(collection__shortname__in=["hom"])
-    datasets_nr_hom = datasets_queryset.filter(f & c).distinct().count()
-    datasets_prc_hom = (
-        int(np.rint(100 * datasets_nr_hom / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    c = Q(collection__shortname__in=["het"])
-    datasets_nr_het = datasets_queryset.filter(f & c).distinct().count()
-    datasets_prc_het = (
-        int(np.rint(100 * datasets_nr_het / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    c = Q(
-        collection__shortname__in=[
-            "hap ?",
-            "hap a/hap alpha/hom",
-            "hap a/hap alpha",
-            "hap a/hom",
-            "hom/het?",
-            "hom/het",
-            "hap a/het",
-            "hap ?/hom/het",
-        ]
-    )
-    datasets_nr_mix = datasets_queryset.filter(f & c).distinct().count()
-    datasets_prc_mix = (
-        int(np.rint(100 * datasets_nr_mix / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    datasets_nr_collections_total = (
-        datasets_nr_hap_a
-        + datasets_nr_hap_alpha
-        + datasets_nr_hom
-        + datasets_nr_het
-        + datasets_nr_mix
-    )
-
-    # c = Q(collection__shortname__in=['hap a', 'hap alpha', 'hom', 'het', 'hap ?', 'hap a/hap alpha/hom',
-    #                                  'hap a/hap alpha', 'hap a/hom', 'hom/het?',
-    #                                  'hom/het', 'hap a/het', 'hap ?/hom/het'])
-    # missing = datasets_queryset.filter(f).exclude(c)
-
-    # --- Data types ---
-    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="q")
-    datasets_nr_q = datasets_queryset.filter(f).distinct().count()
-    datasets_prc_q = (
-        int(np.rint(100 * datasets_nr_q / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="qofh")
-    datasets_nr_qofh = datasets_queryset.filter(f).distinct().count()
-    datasets_prc_qofh = (
-        int(np.rint(100 * datasets_nr_qofh / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    f = Q(paper__in=papers_queryset) & Q(data_available__shortname="d")
-    datasets_nr_d = datasets_queryset.filter(f).distinct().count()
-    datasets_prc_d = (
-        int(np.rint(100 * datasets_nr_d / datasets_nr)) if datasets_nr != 0 else 0
-    )
-
-    datasets_nr_data_available_total = datasets_nr_q + datasets_nr_qofh + datasets_nr_d
-
-    # Data recovery for haploid/homozygous diploid
-    f = Q(paper__in=papers_queryset)
-
-    g1 = Q(
-        data_measured__rank__lt=F("data_published__rank")
-    )  # datasets in need of data recovery
-    g2 = Q(
-        data_available__rank__lt=F("data_published__rank")
-    )  # datasets with recovered data
-
-    h1 = Q(tested_list_published=False)  # datasets in need of tested list recovery
-    h2 = Q(tested_list_published=False) & Q(
-        tested_source_id__isnull=False
-    )  # datasets with recovered tested list
-
-    fgh = f & (g2 | h2)  # all datasets with something recovered
-
-    datasets_nr_need_data = datasets_queryset.filter(f & g1).distinct().count()
-    datasets_nr_need_tested = datasets_queryset.filter(f & h1).distinct().count()
-
-    datasets_nr_recovered_all = datasets_queryset.filter(fgh).distinct().count()
-    datasets_nr_recovered_data = datasets_queryset.filter(f & g2).distinct().count()
-    datasets_nr_recovered_tested = datasets_queryset.filter(f & h2).distinct().count()
-
-    # Heterozygous
-
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def view_cart(request):
+    """View all datasets in the cart, and provide a button to download.
+    """
     context = {
-        "papers_nr": papers_nr,
-        "papers_hopeless_nr": papers_hopeless_nr,
-        "labs_nr": labs_nr,
-        "papers_processed_nr": papers_processed_nr,
-        "phenotypes_nr": phenotypes_nr,
-        "conditions_nr": conditions_nr,
-        "datasets_nr": datasets_nr,
-        "datasets_nr_hap_a": datasets_nr_hap_a,
-        "datasets_prc_hap_a": datasets_prc_hap_a,
-        "datasets_nr_hap_alpha": datasets_nr_hap_alpha,
-        "datasets_prc_hap_alpha": datasets_prc_hap_alpha,
-        "datasets_nr_hom": datasets_nr_hom,
-        "datasets_prc_hom": datasets_prc_hom,
-        "datasets_nr_het": datasets_nr_het,
-        "datasets_prc_het": datasets_prc_het,
-        "datasets_nr_mix": datasets_nr_mix,
-        "datasets_prc_mix": datasets_prc_mix,
-        "datasets_nr_collections_total": datasets_nr_collections_total,
-        "datasets_nr_q": datasets_nr_q,
-        "datasets_prc_q": datasets_prc_q,
-        "datasets_nr_qofh": datasets_nr_qofh,
-        "datasets_prc_qofh": datasets_prc_qofh,
-        "datasets_nr_d": datasets_nr_d,
-        "datasets_prc_d": datasets_prc_d,
-        "datasets_nr_data_available_total": datasets_nr_data_available_total,
-        "datasets_nr_need_data": datasets_nr_need_data,
-        "datasets_nr_need_tested": datasets_nr_need_tested,
-        "datasets_nr_recovered_all": datasets_nr_recovered_all,
-        "datasets_nr_recovered_data": datasets_nr_recovered_data,
-        "datasets_nr_recovered_tested": datasets_nr_recovered_tested,
-        "top_conditiontypes": top_conditiontypes[:10],
-        "updated_on": updated_on,
+        "datasets": Dataset.objects.filter(id__in=request.session.get("cart", []))
     }
-
-    return context
+    return render(request, "cart/view_cart.html", context)
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)

--- a/yeastphenome/apps/conditions/models.py
+++ b/yeastphenome/apps/conditions/models.py
@@ -19,6 +19,9 @@ class Tag(models.Model):
 
 
 class ConditionType(models.Model):
+    """A ConditionType can be temperature, treatment, etc.
+    """
+
     name = models.CharField(max_length=200)
     other_names = models.TextField(blank=True, null=True)
 

--- a/yeastphenome/apps/datasets/models.py
+++ b/yeastphenome/apps/datasets/models.py
@@ -205,6 +205,9 @@ class Dataset(models.Model):
     def __str__(self):
         return "%s" % self.name
 
+    def get_absolute_url(self):
+        return reverse("datasets:detail", args=[self.id])
+
     # Necessary to run database-wide updates of dataset names
     def save(self, *args, **kwargs):
         self.name = "%s | %s | %s | %s | %s" % (

--- a/yeastphenome/apps/datasets/templates/datasets/datasets_table.html
+++ b/yeastphenome/apps/datasets/templates/datasets/datasets_table.html
@@ -10,13 +10,13 @@
     </p>
 </div>
 
-{% if datasets %}
+{% include "messages/message.html" %}
 
-{% if template == 'paper' %}
+{% if datasets %}{% if template == 'paper' %}
 <a href="/{{ template }}s/{{ object.id }}/{{ DOWNLOAD_PREFIX }}_{{ object.pmid }}_datasets_list.txt">Download the list of datasets</a>
 {% endif %}
 
-<form action="/datasets/download/" method="get">
+<form action="{% url 'datasets:download' %}" method="get">
     <table id="papersTable" class="tablesorter table table-condensed table-hover" width="100%">
 
         <thead>
@@ -32,12 +32,11 @@
         </thead>
 
         <tbody>
-        {% for dataset in datasets %}
-        <tr>
+        {% for dataset in datasets %}<tr>
             <td><input id="{{ dataset.id }}" type="checkbox" name="{{ dataset.id }}" class="dataset" {# {% if not dataset.has_data_in_db %}disabled{% endif %} #}></td>
             <td class="col-md-2"><a href="{% url 'papers:detail' dataset.paper.id %}">{{ dataset.paper }}</a></td>
-            <td class="col-md-3">{{ dataset.phenotype.observable2.name }} {% if dataset.phenotype.reporter %} ({{ dataset.phenotype.reporter }}) {% endif %}</td>
-            <td class="col-md-2">{{ dataset.conditionset.display_name }}</td>
+            <td class="col-md-2">{{ dataset.phenotype.observable2.name }} {% if dataset.phenotype.reporter %} ({{ dataset.phenotype.reporter }}) {% endif %}</td>
+            <td class="col-md-1">{{ dataset.conditionset.display_name }}</td>
             <td class="col-md-2">{{ dataset.medium.display_name }}</td>
             <td class="col-md-1">{{ dataset.collection.shortname }}</td>
 
@@ -52,13 +51,11 @@
                 <span class="text-muted">{{ dataset.data_available|capfirst }}</span>
                 {% endif %}
             </td>
-
             <td>
-                <a href="/datasets/{{ dataset.id }}/"><span class="glyphicon glyphicon-plus" aria-hidden="true"></span></a>
+                <a href="/datasets/{{ dataset.id }}/"><button type="button" class="btn btn-primary btn-sm">Details</button></a>
+                {% if dataset.id not in request.session.cart %}<a href="{% url 'common:add_to_cart' dataset.id "datasets:growth" %}"><button type="button" class="btn btn-primary btn-sm" style="width:100px">Add to Cart</button></a>{% else %}<a href="{% url 'common:remove_from_cart' dataset.id "datasets:growth" %}"><button type="button" class="btn btn-danger btn-sm" style="width:100px">Remove</button></a>{% endif %}
             </td>
-        </tr>
-
-        {% endfor %}
+        </tr>{% endfor %}
         </tbody>
     </table>
 

--- a/yeastphenome/apps/phenotypes/models.py
+++ b/yeastphenome/apps/phenotypes/models.py
@@ -310,6 +310,7 @@ class Phenotype(models.Model):
     observable = models.ForeignKey(
         Observable, blank=False, null=False, on_delete=models.CASCADE
     )
+    # an entity that gives us evidence for an observable
     reporter = models.CharField(max_length=200, blank=True, null=True)
     measurement = models.ForeignKey(
         Measurement, blank=True, null=True, on_delete=models.DO_NOTHING


### PR DESCRIPTION
This pull request adds basic views (front and backend) for a datasets cart. The download cart allows a user to add datasets as they browse the website, and we do this via request.session data. A "checkout" page then allows the user to download all the datasets at once, and the general layout has a table of datasets (with an ability to remove one if desired) and a right column that would be good to add some summary of metrics for the download (not implemented yet):

![image](https://user-images.githubusercontent.com/814322/88847859-e1b81200-d1a4-11ea-8f03-8527e232f489.png)

And then the datasets table is the only spot I added an Add/Remove functionality (for now):

![image](https://user-images.githubusercontent.com/814322/88847964-0ad8a280-d1a5-11ea-80fc-d750c57d369a.png)

I don't want to do too much tweaking of the current views until we have the design down. Other somewhat trivial items that I'm adding todo:

 - update urls to to use path, it's easier to read and likely some day the url function could be deprecated
 - the views should have a common base template so each doesn't need to include the header/footer, etc.
 - "add to cart" of course will be sprinkled around the site
 - we should decide on download metrics for the view cart page

I want to try out some of the random GitHub tutorials next.

Signed-off-by: vsoch <vsochat@stanford.edu>