### PR TITLE
adding refactored index to have graph, and papers by year graph

### DIFF
--- a/yeastphenome/apps/common/graphs.py
+++ b/yeastphenome/apps/common/graphs.py
@@ -1,5 +1,4 @@
-from django.shortcuts import render, redirect
-from django.contrib import messages
+from django.shortcuts import render
 
 from ratelimit.decorators import ratelimit
 from yeastphenome.apps.common.utils import get_papers_by_year

--- a/yeastphenome/apps/common/graphs.py
+++ b/yeastphenome/apps/common/graphs.py
@@ -1,0 +1,18 @@
+from django.shortcuts import render, redirect
+from django.contrib import messages
+
+from ratelimit.decorators import ratelimit
+from yeastphenome.apps.common.utils import get_papers_by_year
+from yeastphenome.settings import (
+    VIEW_RATE_LIMIT as rl_rate,
+    VIEW_RATE_LIMIT_BLOCK as rl_block,
+)
+
+# Visuals
+
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def papers_by_year(request):
+    """Render a chart.js visualization for papers by year. Color by year"""
+    context = {"paper_counts": get_papers_by_year()}
+    return render(request, "graphs/papers-by-year-wrapper.html", context)

--- a/yeastphenome/apps/common/templates/base/base.html
+++ b/yeastphenome/apps/common/templates/base/base.html
@@ -52,8 +52,7 @@
     <body>
     <div id="wrap">        
     <link rel="stylesheet" href="{% static 'css/navigation.css' %}">
-    
-    {% include "base/navigation.html" %}
+    {% if request.path == "/" %}{% include "base/navigation-simple.html" %}{% else %}{% include "base/navigation.html" %}{% endif %}
     {% block container %}<div {% if wide %}class="container-wide" style="padding:80px 200px 200px 200px;" {% else %}class="container" style="padding-top:80px; padding-bottom:200px"{% endif %}>{% endblock %}
     {% include "messages/message.html" %}
     {% block content %}{% endblock %}

--- a/yeastphenome/apps/common/templates/base/index.html
+++ b/yeastphenome/apps/common/templates/base/index.html
@@ -7,53 +7,65 @@
         <div class="row">
             <h1 style="color: black; text-align:center">Explore Phenotypic Screens in Yeast</h1><br>
             <div style="max-width: 600px; margin:auto">
-                <input type="text" placeholder="Enter a gene, cell line, lineage or compound" class="homepage-search selectized" id="global-search-dropdown-homepage" tabindex="-1" style="display: none;" value=""><div class="selectize-control homepage-search single"><div class="selectize-input items not-full"><input type="text" autocomplete="off" tabindex="" id="global-search-dropdown-homepage-selectized" placeholder="Enter a gene, cell line, lineage or compound" style="width: 265px; opacity: 1; position: relative; left: 0px;"></div><div class="selectize-dropdown single homepage-search" style="display: none; width: 600px; top: 34px; left: 0px;"><div class="selectize-dropdown-content"></div></div></div>
+                <input type="text" placeholder="Enter a gene, phenotype, or condition." class="homepage-search selectized" id="global-search-dropdown-homepage" tabindex="-1" style="display: none;" value=""><div class="selectize-control homepage-search single"><div class="selectize-input items not-full"><input type="text" autocomplete="off" tabindex="" id="global-search-dropdown-homepage-selectized" placeholder="Enter a gene, cell line, lineage or compound" style="width: 265px; opacity: 1; position: relative; left: 0px;"></div><div class="selectize-dropdown single homepage-search" style="display: none; width: 600px; top: 34px; left: 0px;"><div class="selectize-dropdown-content"></div></div></div>
             </div>
-            <div style="padding-top: 20px; margin:auto; text-align:center">
-                <div class="inline-block" style="padding: 20px 20px 0px 0px">
-                    <div class="inline-block"><img style="width: 44px; border-radius: 12px;" src="#" alt=""></div>
-                    <div class="inline-block"><a class="hotlink" href="#">Data Explorer</a></div>
-                </div>
-                <div class="inline-block" style="padding: 20px 20px 0px 0px">
-                    <div class="inline-block"><img style="width: 44px; border-radius: 12px;" src="#" alt=""></div>
-                    <div class="inline-block"><a class="cursor-pointer hotlink" onclick="#">Cell Line Selector</a></div>
-                </div>
-                <div class="inline-block" style="padding: 20px 0px 0px 0px">
-                    <div class="inline-block"><img style="width: 44px; border-radius: 12px;" src="#" alt=""></div>
-                    <div class="inline-block"><a class="hotlink" href="#">Data Downloads</a></div>
-                </div>
-            </div>
-         </div>
-      </div>
+        </div>
+    </div>
     <div class="col-md-8">
-        <div class="box">
-                <p><a class="box-title" href="{% url 'common:about' %}">About</a></p>
-                <p>Our goal is to collect, organize and share in a standardized format all phenotypic screens of the <em>Saccharomyces cerevisiae</em> deletion collection. <a class="hotlink" href="{% url 'common:about' %}">Learn more</a></p>
-        </div>
-        <div class="box">
-        </div>
-    </div>
-
-    <!--Statistics Panel-->
-    <div class="col-md-4 public-homepage-side-panel">
-        <div class="box">
-            <h3>What is in the database?</h3>
-            <p>General stats on data collection (<a class="hotlink" href="{% url 'common:about' %}">more details</a>):</p>
+        <div class="row">
+            <div class="col-md-6">
+                <div class="box" style="height:200px">
+                    <p><a class="box-title" href="{% url 'common:about' %}">About</a></p>
+                    <p>Our goal is to collect, organize and share in a standardized format all phenotypic screens of the <em>Saccharomyces cerevisiae</em> deletion collection. <a class="hotlink" href="{% url 'common:about' %}">Learn more</a> in the about pages or learn how to <a class="hotlink" href="{% url 'common:getting-started' %}">Get Started</a> </p>
+                </div>
+                <hr>
+                <div class="box" style="height:200px">
+                    <h3>Explore Data</h3>             
+                    <p><ul>
+                    <li><a class="hotlink" href="{% url 'papers:all' %}">Papers</a></li>
+                    <li><a class="hotlink" href="{% url 'phenotypes:index' %}">Phenotypes</a></li>
+                    <li><a class="hotlink" href="{% url 'conditions:index' %}">Conditions</a></li>
+                    <li><a class="hotlink" href="">Special Collections</a></li>
+                    </ul></p>
+                </div>
+            </div>
+            <div class="col-md-6">
+                <div class="box" style="height:200px">
+                    <h3>What is in the database?</h3>
+                    <p>General stats on data collection (<a class="hotlink" href="{% url 'common:about' %}">more details</a>):</p>
             <p><ul>
-                <li>{{ papers_nr }} <a class="hotlink" href="{% url 'papers:all' %}">papers</a></li>
-                <li>{{ phenotypes_nr|intcomma }} <a class="hotlink" href="{% url 'phenotypes:index' %}">phenotypes</a></li>
-                <li>{{ conditions_nr|intcomma }} <a class="hotlink" href="{% url 'conditions:index' %}">experimental conditions</a></li>
-            </ul></p>
-            {% if updated_on %}<p><small>Updated on: {{ updated_on }}.</small></p>{% endif %}
+                    <li>{{ papers_nr }} <a class="hotlink" href="{% url 'papers:all' %}">papers</a></li>
+                    <li>{{ phenotypes_nr|intcomma }} <a class="hotlink" href="{% url 'phenotypes:index' %}">phenotypes</a></li>
+                    <li>{{ conditions_nr|intcomma }} <a class="hotlink" href="{% url 'conditions:index' %}">experimental conditions</a></li>
+                    </ul></p>
+                    {% if updated_on %}<p><small>Updated on: {{ updated_on }}.</small></p>{% endif %}
+                </div>
+                <hr>
+                <div class="box" style="height:200px">
+                    <p><a class="box-title" href="">Downloads</a></p>
+                </div>
+            </div>
         </div>
-        <hr>
-        <div class="box">
-            <h3>Featured Papers</h3>
-            <p>Here we can put a recent, or randomly chosen paper?</p>
+        <div class="row">
+            <div class="col-md-12">
+                <div class="box">
+                {% include "graphs/papers-by-year.html" %} 
+                 <small style="float:right"><a href="{% url 'common:papers-by-year' %}">View Full Width</small>                  
+                </div>
+            </div>
         </div>
     </div>
-</div>
-</div>
+    <div class="col-md-4">
+        <div class="row">
+            <div class="col-md-12 public-homepage-side-panel">
+                <div class="box">
+                  {% if TWITTER_USERNAME %}<div style="max-height:1560px; overflow:scroll">
+                  <br>{% include "social/twitter.html" %}
+                </div>{% endif %}
+            </div>
+        </div>
+    </div>
+</div></div></div>
 <div style="background-color:#f0caa04a;">
    <div style="padding-top: 20px; padding-bottom: 140px" class="container footer-box">
         <div class="row">

--- a/yeastphenome/apps/common/templates/graphs/papers-by-year-wrapper.html
+++ b/yeastphenome/apps/common/templates/graphs/papers-by-year-wrapper.html
@@ -1,0 +1,9 @@
+{% extends "base/base.html" %}
+{% load humanize %}
+{% block content %}
+<div class="row">
+    <div class="col-md-12 box">
+      {% include "graphs/papers-by-year.html" %}
+    </div>
+</div>
+{% endblock %}

--- a/yeastphenome/apps/common/templates/graphs/papers-by-year.html
+++ b/yeastphenome/apps/common/templates/graphs/papers-by-year.html
@@ -1,0 +1,82 @@
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/Chart.js/2.7.2/Chart.min.js"></script>
+<canvas id="papers-by-year-chart"></canvas>
+<script>
+var ctx = document.getElementById("papers-by-year-chart");
+var papersChart = new Chart(ctx, {
+  type: 'bar',
+  data: {
+    labels: [{% for year,count in paper_counts.items %}"{{ year }}"{% if forloop.last %}{% else %},{% endif %}{% endfor %}],
+    datasets: [{
+      label: 'Total Papers',
+      data: [{% for year, count in paper_counts.items %}{
+          t: new Date("{{ year }}"),
+          y: {{ count }}
+        }{% if forloop.last %}{% else %},{% endif %}
+      {% endfor %}],
+      backgroundColor: [{% for year, count in paper_counts.items %}
+         {% if '199' in year|stringformat:"s" %}'rgba(255, 99, 132, 0.2)'
+         {% elif "200" in year|stringformat:"s" %}'rgba(54, 162, 235, 0.2)'
+         {% elif "201" in year|stringformat:"s" %}'rgba(255, 206, 86, 0.2)'
+         {% elif "202" in year|stringformat:"s" %}'rgba(255, 206, 86, 0.2)'
+         {% elif "203" in year|stringformat:"s" %}'rgba(255, 206, 86, 0.2)'
+         {% elif "204" in year|stringformat:"s" %}'rgba(75, 192, 192, 0.2)'
+         {% elif "205" in year|stringformat:"s" %}'rgba(153, 102, 255, 0.2)'
+         {% elif "206" in year|stringformat:"s" %}'rgba(255, 159, 64, 0.2)'{% endif %}
+         {% if forloop.last %}{% else %},{% endif %}{% endfor %}
+      ],
+      borderColor: [{% for year, count in paper_counts.items %}
+         {% if '199' in year|stringformat:"s" %}'rgba(255, 99, 132, 1)'
+         {% elif "200" in year|stringformat:"s" %}'rgba(54, 162, 235, 1)'
+         {% elif "201" in year|stringformat:"s" %}'rgba(255, 206, 86, 1)'
+         {% elif "202" in year|stringformat:"s" %}'rgba(255, 206, 86, 1)'
+         {% elif "203" in year|stringformat:"s" %}'rgba(255, 206, 86, 1)'
+         {% elif "204" in year|stringformat:"s" %}'rgba(75, 192, 192, 1)'
+         {% elif "205" in year|stringformat:"s" %}'rgba(153, 102, 255, 1)'
+         {% elif "206" in year|stringformat:"s" %}'rgba(255, 159, 64, 1)'{% endif %}
+         {% if forloop.last %}{% else %},{% endif %}{% endfor %}
+      ],
+      borderWidth: 1
+    }
+   ]
+  },
+  options: {
+    responsive: true,
+    legend: {
+      display: false
+    },
+    title: {
+      display: true,
+      text: 'Papers Added to YeastPhenome.org by Year'
+    },
+    tooltips: {
+      callbacks: {
+        title: function (tti, data) {
+          return data.labels[tti[0].index];
+        }
+      }
+    },
+    scales: {
+      xAxes: [{
+        categoryPercentage: 1.0,
+        barPercentage: 1.0,
+        tooltipFormat:'MM/DD/YYYY',
+        type: 'time',
+        time: {
+          unit: 'year'
+        },
+        scaleLabel: {
+          display: true,
+          labelString: 'Date'
+        }
+      }],
+      yAxes: [{
+        scaleLabel: {
+          display: true,
+          labelString: 'value'
+        }
+      }]
+    }
+  }
+});
+</script>

--- a/yeastphenome/apps/common/templates/social/twitter.html
+++ b/yeastphenome/apps/common/templates/social/twitter.html
@@ -1,0 +1,17 @@
+{% if TWITTER_USERNAME %}<a class="twitter-timeline" href="https://twitter.com/{{ TWITTER_USERNAME }}?ref_src=twsrc%5Etfw">Updates</a> <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+<script>window.twttr = (function(d, s, id) {
+  var js, fjs = d.getElementsByTagName(s)[0],
+    t = window.twttr || {};
+  if (d.getElementById(id)) return t;
+  js = d.createElement(s);
+  js.id = id;
+  js.src = "https://platform.twitter.com/widgets.js";
+  fjs.parentNode.insertBefore(js, fjs);
+
+  t._e = [];
+  t.ready = function(f) {
+    t._e.push(f);
+  };
+
+  return t;
+}(document, "script", "twitter-wjs"));</script>{% endif %}

--- a/yeastphenome/apps/common/urls.py
+++ b/yeastphenome/apps/common/urls.py
@@ -1,6 +1,7 @@
 from django.urls import path
 
 from . import views
+from . import graphs
 
 urlpatterns = [
     path("", views.index, name="index"),
@@ -15,6 +16,8 @@ urlpatterns = [
         name="remove_from_cart",
     ),
     path("cart/clear/", views.clear_cart, name="clear_cart"),
+    # Graphs
+    path("graph/papers/yearly/", graphs.papers_by_year, name="papers-by-year"),
 ]
 
 app_name = "common"

--- a/yeastphenome/apps/common/utils.py
+++ b/yeastphenome/apps/common/utils.py
@@ -9,6 +9,30 @@ from yeastphenome.apps.conditions.models import ConditionSet, ConditionType
 from yeastphenome.apps.phenotypes.models import Phenotype
 from yeastphenome.apps.datasets.models import Dataset
 
+import collections
+
+# Papers
+
+
+def get_papers_by_year(add_padding=True):
+    """Generate a dictionary of papers by year. If add_padding is True,
+       add an empty year to the left and right (default)
+    """
+    counts = (
+        Paper.objects.values("pub_date")
+        .order_by("pub_date")
+        .annotate(the_count=Count("pub_date"))
+    )
+    counts = {x["pub_date"]: x["the_count"] for x in counts if x["pub_date"] != 0}
+
+    # Add padding on left and right for one year
+    if add_padding:
+        min_year = min(counts.keys())
+        max_year = max(counts.keys())
+        counts[min_year - 1] = 0
+        counts[max_year + 1] = 0
+    return collections.OrderedDict(sorted(counts.items()))
+
 
 # Stats helper function
 

--- a/yeastphenome/apps/common/views.py
+++ b/yeastphenome/apps/common/views.py
@@ -2,7 +2,7 @@ from django.shortcuts import render, redirect
 from django.contrib import messages
 
 from yeastphenome.apps.common.forms import SearchForm
-from yeastphenome.apps.common.utils import get_latest_stats
+from yeastphenome.apps.common.utils import get_latest_stats, get_papers_by_year
 from yeastphenome.apps.datasets.models import Dataset
 
 from ratelimit.decorators import ratelimit
@@ -20,6 +20,7 @@ def index(request):
     form = SearchForm()
     context = get_latest_stats()
     context["form"] = form
+    context["paper_counts"] = get_papers_by_year()
     return render(request, "base/index.html", context)
 
 

--- a/yeastphenome/apps/papers/urls.py
+++ b/yeastphenome/apps/papers/urls.py
@@ -1,19 +1,19 @@
-from django.conf.urls import url
+from django.urls import path
 from yeastphenome import settings
 
 from . import views
 
 urlpatterns = [
-    url(r"^$", views.paper_list_view, name="all"),
-    url(r"^(?P<pk>\d+)/$", views.PaperDetailView.as_view(), name="detail"),
+    path("", views.paper_list_view, name="all"),
+    path("<int:pk>", views.PaperDetailView.as_view(), name="detail"),
     # Data
-    url(
-        r"^(?P<paper_id>\d+)/%s_(?P<paper_pmid>\d+).zip$" % settings.DOWNLOAD_PREFIX,
+    path(
+        "<int:paper_id>/%s_<int:paper_pmid>.zip" % settings.DOWNLOAD_PREFIX,
         views.download_zip,
         name="download_zip",
     ),
-    url(
-        r"^(?P<paper_id>\d+)/%s_(\d+)_datasets_list.txt$" % settings.DOWNLOAD_PREFIX,
+    path(
+        "<int:paper_id>/%s_(\d+)_datasets_list.txt" % settings.DOWNLOAD_PREFIX,
         views.paper_datasets,
         name="paper_datasets",
     ),


### PR DESCRIPTION
This will add the first simple chart, the papers by year bar plot! I'll follow up in a summary email with details (discussion of colors, etc.) It currently renders on the refactored index:

![image](https://user-images.githubusercontent.com/814322/90165508-004a0b80-dd56-11ea-975a-ec61bdd371ea.png)

along with it's own "Full Width" view, which the user can reach by clicking the link under the chart (and likely other places on the site).

![image](https://user-images.githubusercontent.com/814322/90165583-18218f80-dd56-11ea-8e83-d355eb50f2e3.png)

Signed-off-by: vsoch <vsochat@stanford.edu>