### PR TITLE
adding basic subnavigation to menus

### DIFF
--- a/yeastphenome/apps/common/templates/base/navigation.html
+++ b/yeastphenome/apps/common/templates/base/navigation.html
@@ -74,6 +74,9 @@
               <li><a href="{% url 'papers:all' %}">Papers</a></li>            
               <li><a href="{% url 'phenotypes:index' %}">Phenotypes</a></li>
               <li><a href="{% url 'conditions:index' %}">Conditions</a></li>
+              {% if links %}<li style="margin: 8px 0" role="separator" class="divider"></li>
+              {% for link in links %}<li><a href="{{ link.url }}">{{ link.name }}</a></li>{% endfor %}
+              {% endif %}
           </ul>
         {% if HELP_CONTACT_EMAIL %}<li class="visible-xs-block"><a href="mailto:{{ HELP_CONTACT_EMAIL }}"><i class="fas fa-envelope-open"></i> {{ HELP_CONTACT_EMAIL }}</a></li>{% endif %}
         {% if TWITTER_USERNAME %}<li class="visible-xs-block"><a href="https://twitter.com/{{ TWITTER_USERNAME }}" target="_blank" rel="noopener"><i class="fab fa-twitter"></i> @{{ TWITTER_USERNAME }}</a></li>{% endif %}

--- a/yeastphenome/apps/conditions/views.py
+++ b/yeastphenome/apps/conditions/views.py
@@ -3,7 +3,7 @@ import re
 from django.db.models import Count
 from django.conf import settings
 from django.core.paginator import Paginator
-from django.shortcuts import render
+from django.shortcuts import reverse, render
 from django.views import generic
 from django.http import Http404
 
@@ -93,6 +93,12 @@ class ConditiontypeDetailView(generic.DetailView, RatelimitMixin):
         context["USER_AUTH"] = self.request.user.is_authenticated
         context["papers"] = context["object"].datasets
         context["id"] = context["object"].id
+        context["links"] = [
+            {
+                "url": reverse("conditions:detail", args=[context["object"].id]),
+                "name": "Condition (%s)" % context["object"].name,
+            }
+        ]
         return context
 
 

--- a/yeastphenome/apps/datasets/views.py
+++ b/yeastphenome/apps/datasets/views.py
@@ -1,7 +1,7 @@
 from django.db.models import Q
 from django.shortcuts import render
 from django.http import HttpResponse, Http404
-from django.shortcuts import get_object_or_404
+from django.shortcuts import get_object_or_404, reverse
 from django.conf import settings
 from django.core.paginator import Paginator
 from django.contrib import messages
@@ -73,6 +73,14 @@ class DatasetDetailView(generic.DetailView, RatelimitMixin):
             .values_list("gene__systematic_name", "gene__common_name", "value")
         )
 
+        # Links should include the dataset detail page
+        links = [
+            {
+                "url": reverse("datasets:detail", args=[context["dataset"].id]),
+                "name": "Dataset %s" % context["dataset"].id,
+            }
+        ]
+
         datasets_top = queryset[:10]
         datasets_bottom = []
         if queryset.count() >= 10:
@@ -80,6 +88,7 @@ class DatasetDetailView(generic.DetailView, RatelimitMixin):
             datasets_bottom.reverse()
         context["datasets_top"] = datasets_top
         context["datasets_bottom"] = datasets_bottom
+        context["links"] = links
         return context
 
 
@@ -95,9 +104,20 @@ def dataset_plot(request, dataset_id):
     except Dataset.DoesNotExist:
         raise Http404
 
+    links = [
+        {
+            "url": reverse("datasets:detail", args=[dataset.id]),
+            "name": "Dataset %s" % dataset.id,
+        },
+        {
+            "url": reverse("datasets:dataset_plot", args=[dataset.id]),
+            "name": "Phenotypic Scores",
+        },
+    ]
+
     # prepare list of genes, plus genes and aliases
     context = get_dataset_gene_table_context(dataset)
-    context.update({"dataset": dataset})
+    context.update({"dataset": dataset, "links": links})
     return render(request, "datasets/plot.html", context)
 
 
@@ -170,6 +190,15 @@ def gene_explorer(request):
                 Q(systematic_name__iexact=query) | Q(common_name__iexact=query)
             )
 
+            # Assemble links
+            links = [
+                {
+                    "url": "%s?q=%s"
+                    % (reverse("datasets:genes"), gene.systematic_name),
+                    "name": "Gene %s" % gene.systematic_name,
+                }
+            ]
+
             # If not found, try for an alias
             if not gene:
                 gene = GeneAlias.objects.get(name__iexact=query).gene_set.first()
@@ -194,6 +223,7 @@ def gene_explorer(request):
             context["datasets_top"] = queryset[:10]
             context["datasets_bottom"] = queryset[len(queryset) - 10 :]
             context["datasets_bottom"].reverse()
+            context["links"] = links
 
         except Gene.DoesNotExist:
             messages.warning(
@@ -220,10 +250,22 @@ def similar_genes(request, systematic_name):
         .order_by("-score")
         .distinct()
     )
+
+    links = [
+        {
+            "url": "%s?q=%s" % (reverse("datasets:genes"), gene.systematic_name),
+            "name": "Gene %s" % gene.systematic_name,
+        },
+        {
+            "url": reverse("datasets:similar_genes", args=[gene.systematic_name]),
+            "name": "Similar Genes",
+        },
+    ]
+
     total_sims = sims.count()
     ranks = [(1 - (idx / total_sims)) * 100 for idx, sim in enumerate(sims)]
     context = get_gene_names_context()
-    context.update({"gene": gene, "sims": sims, "ranks": ranks})
+    context.update({"gene": gene, "sims": sims, "ranks": ranks, "links": links})
     return render(request, "genes/similar_genes.html", context)
 
 
@@ -242,9 +284,19 @@ def similar_dataset_table(request, dataset_id):
         .distinct()
     )
 
+    links = [
+        {
+            "url": reverse("datasets:detail", args=[dataset.id]),
+            "name": "Dataset %s" % dataset.id,
+        },
+        {
+            "url": reverse("datasets:similar_dataset_table", args=[dataset.id]),
+            "name": "Similar Datasets",
+        },
+    ]
     total = sims.count()
     ranks = [(1 - (idx / total)) * 100 for idx, sim in enumerate(sims)]
-    context = {"dataset": dataset, "datasets": sims, "ranks": ranks}
+    context = {"dataset": dataset, "datasets": sims, "ranks": ranks, "links": links}
     return render(request, "datasets/dataset_similarity_explorer.html", context)
 
 
@@ -264,10 +316,21 @@ def gene_datasets(request, systematic_name):
         .exclude(Q(value=None) | Q(value=Decimal("NaN")))
         .order_by("-value")
     )
+    links = [
+        {
+            "url": "%s?q=%s" % (reverse("datasets:genes"), gene.systematic_name),
+            "name": "Gene %s" % gene.systematic_name,
+        },
+        {
+            "url": reverse("datasets:gene_datasets", args=[gene.systematic_name]),
+            "name": "Gene Datasets",
+        },
+    ]
+
     total = queryset.count()
     ranks = [(1 - (idx / total)) * 100 for idx, sim in enumerate(queryset)]
     context = get_gene_names_context()
-    context.update({"gene": gene, "datasets": queryset, "ranks": ranks})
+    context.update({"gene": gene, "datasets": queryset, "ranks": ranks, "links": links})
     return render(request, "genes/gene_datasets.html", context)
 
 

--- a/yeastphenome/apps/papers/views.py
+++ b/yeastphenome/apps/papers/views.py
@@ -1,6 +1,6 @@
 from django.db.models import Q
 from django.views import generic
-from django.shortcuts import render
+from django.shortcuts import render, reverse
 from django.core.paginator import Paginator
 
 from django.views.decorators.cache import never_cache
@@ -85,6 +85,12 @@ class PaperDetailView(generic.DetailView, RatelimitMixin):
         context = super(PaperDetailView, self).get_context_data(**kwargs)
         paper = context["object"]
 
+        context["links"] = [
+            {
+                "url": reverse("papers:detail", args=[paper.id]),
+                "name": "Paper %s" % paper.id,
+            }
+        ]
         context["DOWNLOAD_PREFIX"] = settings.DOWNLOAD_PREFIX
         context["USER_AUTH"] = self.request.user.is_authenticated
 

--- a/yeastphenome/apps/phenotypes/views.py
+++ b/yeastphenome/apps/phenotypes/views.py
@@ -1,7 +1,7 @@
 from django.core.paginator import Paginator
 from django.conf import settings
 from django.views import generic
-from django.shortcuts import render
+from django.shortcuts import render, reverse
 from django.db import models
 from django.http import Http404
 
@@ -75,6 +75,12 @@ class ObservableDetailView(generic.DetailView):
         context = super(ObservableDetailView, self).get_context_data(**kwargs)
         context["DOWNLOAD_PREFIX"] = settings.DOWNLOAD_PREFIX
         context["USER_AUTH"] = self.request.user.is_authenticated
+        context["links"] = [
+            {
+                "url": reverse("phenotypes:detail", args=[context["object"].id]),
+                "name": "Phenotype %s" % context["object"].id,
+            }
+        ]
 
         # most similar tags, sort highest on top
         qs = Observable.objects.all().annotate(count=models.Count("pk"))


### PR DESCRIPTION
This PR will add basic subnavigation to menus, meaning that when we go deeper into the site, the top navigations extend to include the trail of submenus.

Signed-off-by: vsoch <vsochat@stanford.edu>