### PR TITLE
updating conditions browser to use treemap

### DIFF
--- a/yeastphenome/apps/common/templates/main/stats.html
+++ b/yeastphenome/apps/common/templates/main/stats.html
@@ -177,13 +177,13 @@
         <span href="#" class="list-group-item active">
             Publications
         </span>
-        <a href="#maintainers" class="list-group-item">
+        <a href="#phenotypes" class="list-group-item">
             Phenotypes
         </a>
-        <a href="#curators" class="list-group-item">
+        <a href="#environments" class="list-group-item">
             Environments
         </a>
-        <a href="#programmers" class="list-group-item">
+        <a href="#datasets" class="list-group-item">
             Datasets
         </a>
     </div>

--- a/yeastphenome/apps/conditions/templates/conditions/graphs/browse.html
+++ b/yeastphenome/apps/conditions/templates/conditions/graphs/browse.html
@@ -2,65 +2,117 @@
 {% block title %}{{ object|capfirst }} / Experimental conditions / {{ SITE_NAME }}{% endblock %}
 {% block container %}
 <style>
-text {
-  font: 12px sans-serif;
+form {
+  font-family: sans-serif;
 }
-.node {
+
+rect {
   cursor: pointer;
 }
+
+svg {
+  font: 10px sans-serif;
+  float: left;
+  padding-left:30px;
+}
 </style>
-<div class="row" style="padding-left:30px; padding-bottom:30px">
+<div class="row" style="padding-left:30px; padding-bottom:20px">
     <div class="col-md-12">
         <h1>Browse Conditions</h1>
         <small>Top 100 By number of associated datasets</small>
-        <div id="vis"></div>
     </div>
 </div>
-{% endblock %}
-{% block scripts %}
-<script src="//d3js.org/d3.v4.js"></script>
+<div class="row" style="margin-bottom:200px">
+    <div class="col-md-12">
+        <svg width="1400" height="900"></div>
+    </div>
+</div>
+<script src="https://d3js.org/d3.v4.min.js"></script>
 <script>
-
 // {packageName: name, className: node.name, value: node.size});
-data = [{% for entry in data %}{% if entry.name != "standard" %}{"id": {{ entry.id }},"packageName": "{{entry.name}}", "className": "{{entry.name}}", "value": {{entry.number_of_datasets}} }{% if forloop.last %}{% else %},{% endif %}{% endif %}{% endfor %}]
+nodes = [{% for entry in data %}{% if entry.name != "standard" %}{"name": "{{ entry.name }}", "size": {{entry.number_of_datasets}}, "uid": {{ entry.id }} }{% if forloop.last %}{% else %},{% endif %}{% endif %}{% endfor %}]
+      
+var svg = d3.select("svg"),
+    width = +svg.attr("width"),
+    height = +svg.attr("height");
 
-var width = 1400,
-    height = 900,
-    format = d3.format(",d"),
-    color = d3.scaleOrdinal(d3.schemeCategory20c);
+var fader = function(color) { return d3.interpolateRgb(color, "#fff")(0.2); },
+    color = d3.scaleOrdinal(d3.schemeCategory20.map(fader)),
+    format = d3.format(",d");
 
-var bubble = d3.pack()
+var treemap = d3.treemap()
+    .tile(d3.treemapResquarify)
     .size([width, height])
-    .padding(10.5);
+    .round(true)
+    .paddingInner(1);
 
-var svg = d3.select("#vis").append("svg")
-    .attr("width", width)
-    .attr("height", height)
-    .attr("class", "bubble");
+  var data = {"name": "root", "children": nodes}
+  
+  var root = d3.hierarchy(data)
+      .eachBefore(function(d) { d.data.id = (d.parent ? d.parent.data.id + "." : "") + d.data.name; })
+      .sum(sumBySize)
+      .sort(function(a, b) { return b.height - a.height || b.value - a.value; });
 
-  var root = d3.hierarchy({"children": data})
-      .sum(function(d) { return d.value; })
-      .sort(function(a, b) { return b.value - a.value; });
+  treemap(root);
 
-  bubble(root);
-  var node = svg.selectAll(".node")
-      .data(root.children)
+  var cell = svg.selectAll("g")
+    .data(root.leaves())
     .enter().append("g")
-      .attr("class", "node")
-      .attr("transform", function(d) { return "translate(" + d.x + "," + d.y + ")"; });
+      .attr("transform", function(d) { return "translate(" + d.x0 + "," + d.y0 + ")"; });
 
-  node.append("title")
-      .text(function(d) { return d.data.className + ": " + format(d.value); });
+  cell.append("rect")
+      .attr("id", function(d) { return d.data.id; })
+      .attr("width", function(d) { return d.x1 - d.x0; })
+      .attr("height", function(d) { return d.y1 - d.y0; })
+      .attr("fill", function(d) { return color(d.value); })
+      .on("click", function(d){ console.log(d); document.location = "/conditions/" + d.data.uid});
 
-  node.append("circle")
-      .attr("r", function(d) { return d.r; })
-      .style("fill", function(d) { return color(d.data.packageName)})
-      .on("click", function(d){ document.location = "/conditions/" + d.data.id})
+  cell.append("clipPath")
+      .attr("id", function(d) { return "clip-" + d.data.id; })
+    .append("use")
+      .attr("xlink:href", function(d) { return "#" + d.data.id; });
 
-  node.append("text")
-      .attr("dy", ".3em")
-      .style("text-anchor", "middle")
-      .text(function(d) { return d.data.className.substring(0, d.r / 4); });
+  cell.append("text")
+      .attr("clip-path", function(d) { return "url(#clip-" + d.data.id + ")"; })
+    .selectAll("tspan")
+      .data(function(d) { return d.data.name.split(/(?=[A-Z][^A-Z])/g); })
+    .enter().append("tspan")
+      .attr("x", 4)
+      .attr("y", function(d, i) { return 13 + i * 10; })
+      .text(function(d) { return d; });
 
+  cell.append("title")
+      .text(function(d) { return d.data.id + "\n" + format(d.value); });
+
+  d3.selectAll("input")
+      .data([sumBySize, sumByCount], function(d) { return d ? d.name : this.value; })
+      .on("change", changed);
+
+  var timeout = d3.timeout(function() {
+    d3.select("input[value=\"sumByCount\"]")
+        .property("checked", true)
+        .dispatch("change");
+  }, 2000);
+
+  function changed(sum) {
+    timeout.stop();
+
+    treemap(root.sum(sum));
+
+    cell.transition()
+        .duration(750)
+        .attr("transform", function(d) { return "translate(" + d.x0 + "," + d.y0 + ")"; })
+      .select("rect")
+        .attr("width", function(d) { return d.x1 - d.x0; })
+        .attr("height", function(d) { return d.y1 - d.y0; });
+  }
+
+function sumByCount(d) {
+  return d.children ? 0 : 1;
+}
+
+function sumBySize(d) {
+  return d.size;
+}
 </script>
 {% endblock %}


### PR DESCRIPTION
This is a refactor of the conditions browse view to try different chart types. I also tried a bar plot, but given N=100 and that a few entries are very large (and the rest small in comparison) it was very hard to see most of the smaller ones (there was one big, skinny bar and then a long tail). I decided instead to try a treemap, which at least would be able to show the entries with text.
![image](https://user-images.githubusercontent.com/814322/98029836-63839100-1dcd-11eb-8fad-fbb6bc36dd94.png)

The color isn't meaningful here (usually you do it based on some parent, but in our case the tree is flat) but it could be.

Signed-off-by: vsoch <vsochat@stanford.edu>