### PR TITLE
fixing admin save, cannot return None

### DIFF
--- a/yeastphenome/apps/common/admin_util.py
+++ b/yeastphenome/apps/common/admin_util.py
@@ -95,6 +95,7 @@ class ImprovedModelAdmin(admin.ModelAdmin):
             return HttpResponse(
                 '<script type="text/javascript">window.opener.location.reload(); window.close();</script>'
             )
+        return super().response_change(request, obj)
 
 
 class LimitedInlineFormSet(BaseInlineFormSet):

--- a/yeastphenome/apps/conditions/admin.py
+++ b/yeastphenome/apps/conditions/admin.py
@@ -167,7 +167,12 @@ class ConditionTypeAdmin(ImprovedModelAdmin):
             obj.chebi_name = None
         if form.cleaned_data["pubchem_id"]:
             comp = Compound.from_cid(form.cleaned_data["pubchem_id"])
-            obj.pubchem_name = comp.synonyms[0]
+
+            # Not all compounds have synonyms, fall back to iupac_name
+            if comp.synonyms:
+                obj.pubchem_name = comp.synonyms[0]
+            else:
+                obj.pubchem_name = comp.iupac_name
         else:
             obj.pubchem_name = None
         obj.save()

--- a/yeastphenome/apps/datasets/admin.py
+++ b/yeastphenome/apps/datasets/admin.py
@@ -25,7 +25,7 @@ class DatasetAdminForm(forms.ModelForm):
 
     def clean(self):
         cleaned_data = super(DatasetAdminForm, self).clean()
-        cleaned_data["name"] = u"%s | %s | %s | %s | %s" % (
+        cleaned_data["name"] = "%s | %s | %s | %s | %s" % (
             cleaned_data["collection"],
             cleaned_data["phenotype"],
             cleaned_data["conditionset"],


### PR DESCRIPTION
This pull request fixes two small bugs on the current staging server, specifically:

 - when we save a model, we have over-ridden the response_change function and need to run super() after checking for a popup, because if it's not that case, we are returning None (and the view needs a response).
 - the Componud.from_cid sometimes doesn't have synonyms, so we cannot index at 0.

@abarysh I wanted to ask you about the second case, because the one I was testing didn't have a synonym, but in the interface clearly had a value that must have come from somewhere?

![Screenshot_2020-11-06 Change condition type Django site admin](https://user-images.githubusercontent.com/814322/98397387-85bf1e00-201c-11eb-85f3-ef732577bf48.png)

I looked at the attributes on the comp result, and looking at other instances of ConditionType it looks like we are falling back to the comp.iupac_name (what I implemented here) however for this particular test case, I'm not sure where the value came from. We did change the pubmed_id from an int to a text field, so I tried retrieving the compound both ways (id as string and int) and the same thing is returned, so it's not that.

I think we have two options - either check for the synonym and fallback to the iupac_name, or check for the synonym and leave as None (don't add it) if it's not there.

Once this looks good, I'll merge and deploy to staging for you to preview! Then we can push to production when you give the signal.

Signed-off-by: vsoch <vsochat@stanford.edu>