### PR TITLE
adding ability to download paperset list to paper admin

### DIFF
--- a/yeastphenome/apps/common/templates/admin/datasets_inline.html
+++ b/yeastphenome/apps/common/templates/admin/datasets_inline.html
@@ -1,4 +1,5 @@
 {% load i18n admin_urls static admin_modify %}
+
 <div class="js-inline-admin-formset inline-group" id="{{ inline_admin_formset.formset.prefix }}-group"
      data-inline-type="tabular"
      data-inline-formset="{{ inline_admin_formset.inline_formset_data }}">
@@ -71,5 +72,8 @@
                 </tbody>
             </table>
         </fieldset>
+        {% if original.datasets_number > 0 %}<table style="width:100%">
+        <tr class="add-row"><td colspan="6"><a href="/{{ opts.model_name }}s/{{ original.id }}/{{ DOWNLOAD_PREFIX }}_{{ original.pmid }}_datasets_list.txt">Download the list of datasets</a></td></tr>
+        </table>{% endif %}
     </div>
 </div>

--- a/yeastphenome/apps/common/templates/admin/datasets_inline.html
+++ b/yeastphenome/apps/common/templates/admin/datasets_inline.html
@@ -73,7 +73,7 @@
             </table>
         </fieldset>
         {% if original.datasets_number > 0 %}<table style="width:100%">
-        <tr class="add-row"><td colspan="6"><a href="/{{ opts.model_name }}s/{{ original.id }}/{{ DOWNLOAD_PREFIX }}_{{ original.pmid }}_datasets_list.txt">Download the list of datasets</a></td></tr>
+        <tr class="add-row"><td colspan="6"><a style="background:none" href="/{{ opts.model_name }}s/{{ original.id }}/{{ DOWNLOAD_PREFIX }}_{{ original.pmid }}_datasets_list.txt">Download the list of datasets</a></td></tr>
         </table>{% endif %}
     </div>
 </div>

--- a/yeastphenome/apps/datasets/templates/datasets/datasets_table.html
+++ b/yeastphenome/apps/datasets/templates/datasets/datasets_table.html
@@ -8,10 +8,6 @@
     cursor: default;
 }
 </style>
-{% if template == 'paper' %}
-<a href="/{{ template }}s/{{ object.id }}/{{ DOWNLOAD_PREFIX }}_{{ object.pmid }}_datasets_list.txt">Download the list of datasets</a>
-{% endif %}
-
 <form action="{% url 'datasets:download' %}" method="get">
     {% csrf_token %}
     <table id="papersTable" class="tablesorter table table-condensed table-hover" width="100%" {% if datasets %}{% else %}style="display:none"{% endif %}>

--- a/yeastphenome/apps/papers/templates/papers/detail.html
+++ b/yeastphenome/apps/papers/templates/papers/detail.html
@@ -64,7 +64,7 @@
 <div class="row" style="padding-top:30px" id="datasets">
     <div class="col-xs-12">
         <h2>Datasets</h2>
-        {% include "datasets/datasets_table.html" with template='paper' notitle='true' %}
+        {% include "datasets/datasets_table.html" with notitle='true' %}
      </div>
 </div>
 <div class="row" style="padding-top:30px" id="curation">

--- a/yeastphenome/apps/papers/urls.py
+++ b/yeastphenome/apps/papers/urls.py
@@ -15,7 +15,7 @@ urlpatterns = [
         name="download_zip",
     ),
     path(
-        "<int:paper_id>/%s_(\d+)_datasets_list.txt" % settings.DOWNLOAD_PREFIX,
+        "<int:paper_id>/%s_<int:pmid>_datasets_list.txt" % settings.DOWNLOAD_PREFIX,
         views.paper_datasets,
         name="paper_datasets",
     ),

--- a/yeastphenome/apps/papers/views.py
+++ b/yeastphenome/apps/papers/views.py
@@ -194,7 +194,7 @@ def download_zip(request, paper_id, paper_pmid):
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)
-def paper_datasets(request, paper_id):
+def paper_datasets(request, paper_id, pmid):
     p = get_object_or_404(Paper, pk=paper_id)
 
     txt = "\n".join([(u"%s\t%s" % (d.id, d.name)) for d in p.dataset_set.all()])

--- a/yeastphenome/context_processors.py
+++ b/yeastphenome/context_processors.py
@@ -7,6 +7,7 @@ def globals(request):
     correcty in the settings.py file."""
     return {
         "DOMAIN": settings.DOMAIN_NAME,
+        "DOWNLOAD_PREFIX": settings.DOWNLOAD_PREFIX,
         "TWITTER_USERNAME": settings.TWITTER_USERNAME,
         "GITHUB_REPOSITORY": settings.GITHUB_REPOSITORY,
         "GITHUB_DOCUMENTATION": settings.GITHUB_DOCUMENTATION,


### PR DESCRIPTION
This pull request will add a button to download a list of datasets for a paper to the admin view, and remove it from the paper external view. Specifically, I had two options:

 - Figure out the javascript + model combined logic to generate the `Add additional <model>` row and thus add a button next to it
 - A simpler approach to add a custom row just to the Dataset Inline present in (what looks like) just the papers change form view.

The second is easier to see and figure out, and also wouldn't require further customizing the custom inline class so I opted for this approach. This means that for a paper with many datasets, we have a download button in a second row that looks like this:

![image](https://user-images.githubusercontent.com/814322/98598164-47816300-2297-11eb-9c67-0aad6018d4de.png)

And for a paper without datasets, it's not rendered.

![image](https://user-images.githubusercontent.com/814322/98598204-56681580-2297-11eb-94fb-543fa3cfa90f.png)

The download button (working) is also restored. @abarysh is this an okay solution for #55? 
 
Signed-off-by: vsoch <vsochat@stanford.edu>