### PR TITLE
tweaking inputs for explorer pages to not show unstyled box

### DIFF
--- a/docs/_docs/development/index.md
+++ b/docs/_docs/development/index.md
@@ -129,6 +129,21 @@ A secret key is used to secure your server. You can use the [secret key generato
 export DJANGO_SECRET_KEY=123455
 ```
 
+#### Disable Cache
+
+We have the ability to use a filesystem cache, meaning a folder in /tmp (`/tmp/yeast-phenome-cache`) that can save pages when we are developing, or on app engine. Since we've better
+optimized most pages, we don't need this cache, and so it's recommended to export
+this disable cache variable:
+
+```bash
+export DISABLE_CACHE=true
+```
+
+If you find that you are developing and pages aren't changing, likely you forgot
+to export this before starting the server, and you can stop the server, delete
+the temporary folder, export the variable, and start it again.
+
+
 #### Google Analytics
 
 If you want to use [Google Analytics](https://analytics.google.com/analytics/web/) with your application, generate a key and add it to your application, again in the `.env` file.

--- a/yeastphenome/apps/conditions/templates/conditions/explorer.html
+++ b/yeastphenome/apps/conditions/templates/conditions/explorer.html
@@ -60,7 +60,7 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
             <div class="col-md-10 public-homepage-side-panel">
                 <h1>Conditions</h1>
                 <div>
-                  <input name='tags' value="">
+                  <input name='tags' value="" style="display:none">
                 </div>
             </div>
             <div class="col-md-2">
@@ -91,9 +91,10 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
     </div>
 </div></div>
 {% endblock %}
-{% block scripts %}
-
+{% block head %}
 <script src="{% static 'js/tagify-3.17.7.min.js' %}"></script>
+{% endblock %}
+{% block scripts %}
 <script>
 
 var tags = {{ tags | safe }}

--- a/yeastphenome/apps/datasets/templates/datasets/explorer.html
+++ b/yeastphenome/apps/datasets/templates/datasets/explorer.html
@@ -60,7 +60,7 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
             <div class="col-md-12 public-homepage-side-panel">
                 <h1>Datasets</h1>
                 <div>
-                  <input name='tags' value="">
+                  <input style="display:none" name='tags' value="">
                 </div>
             </div>
         </div>
@@ -85,8 +85,10 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
     </div>
 </div></div>
 {% endblock %}
-{% block scripts %}
+{% block head %}
 <script src="{% static 'js/tagify-3.17.7.min.js' %}"></script>
+{% endblock %}
+{% block scripts %}
 <script>
 
 var cart = {{ cart | safe }}

--- a/yeastphenome/apps/datasets/templates/genes/index.html
+++ b/yeastphenome/apps/datasets/templates/genes/index.html
@@ -61,7 +61,7 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
             <div class="col-md-12 public-homepage-side-panel">
                 <h1>Genes</h1>
                 <div>
-                  <input name='tags' value="">
+                  <input name='tags' value="" style="display:none">
                 </div>
             </div>
         </div>
@@ -86,8 +86,10 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
     </div>
 </div></div>
 {% endblock %}
-{% block scripts %}
+{% block head %}
 <script src="{% static 'js/tagify-3.17.7.min.js' %}"></script>
+{% endblock %}
+{% block scripts %}
 <script>
 
 var tags = {{ tags | safe }}

--- a/yeastphenome/apps/papers/templates/papers/explorer.html
+++ b/yeastphenome/apps/papers/templates/papers/explorer.html
@@ -60,7 +60,7 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
             <div class="col-md-12 public-homepage-side-panel">
                 <h1 style="padding-bottom:25px">Papers</h1>
                 <div>
-                  <input name='tags' value="">
+                  <input name='tags' value="" style="display:none">
                 </div>
             </div>
         </div>
@@ -86,8 +86,10 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
     </div>
 </div></div>
 {% endblock %}
-{% block scripts %}
+{% block head %}
 <script src="{% static 'js/tagify-3.17.7.min.js' %}"></script>
+{% endblock %}
+{% block scripts %}
 <script>
 
 var tags = {{ tags | safe }}

--- a/yeastphenome/apps/phenotypes/templates/phenotypes/explorer.html
+++ b/yeastphenome/apps/phenotypes/templates/phenotypes/explorer.html
@@ -60,7 +60,7 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
             <div class="col-md-12 public-homepage-side-panel">
                 <h1>Phenotypes</h1>
                 <div>
-                    <input name='tags' value="">
+                    <input name='tags' value="" style="display:none">
                 </div>
             </div>
             <!--<div class="col-md-2">
@@ -90,13 +90,13 @@ label[for='checkbox-tagify-show-input'] + input:checked ~ textaragifyea{
     </div>
 </div></div>
 {% endblock %}
-{% block scripts %}
-
+{% block head %}
 <script src="{% static 'js/tagify-3.17.7.min.js' %}"></script>
+{% endblock %}
+{% block scripts %}
 <script>
 
 var tags = {{ tags | safe }}
-console.log(tags)
 
 var input = document.querySelector('input[name=tags]'),
     tagify = new Tagify(input, {


### PR DESCRIPTION
Hey @abarysh ! This is a small set of changes that will basically load the tagify script in the head, and then hide the unstyled box. There is still a slight pause in loading the styled box, but this is an improvement because we don't see the unstyled one. Let me know if this is okay to merge, and then deploy to staging.

Signed-off-by: vsoch <vsochat@stanford.edu>