### PR TITLE
Hide scores for datasets without release permission

### DIFF
--- a/yeastphenome/apps/api/datasets.py
+++ b/yeastphenome/apps/api/datasets.py
@@ -109,10 +109,14 @@ def generate_datasets(request, data, datasets, query=None):
     # Since we have a small queryset (25) we can loop over without it being too slow
     for dataset in datasets:
 
+        disabled = ''
+        if not dataset.data_source.release:
+            disabled = 'disabled'
+
         if dataset.id not in cart:
             button = (
-                '<button id="dataset-cart-%s" type="button" class="btn btn-primary btn-sm add-to-cart" style="width:120px" data-id="%s">Add</button>'
-                % (dataset.id, dataset.id)
+                '<button id="dataset-cart-%s" type="button" class="btn btn-primary btn-sm add-to-cart" style="width:120px" data-id="%s" %s>Add</button>'
+                % (dataset.id, dataset.id, disabled)
             )
         else:
             button = (

--- a/yeastphenome/apps/common/templates/graphs/dataset-genes/index.html
+++ b/yeastphenome/apps/common/templates/graphs/dataset-genes/index.html
@@ -55,7 +55,7 @@ tr.highlight {
         <thead>
         <tr>
             <th class="text-nowrap" width="30%">Gene Name</th>
-            <th width="30%">Value</th>
+            <th width="30%">Normalized Phenotypic Score</th>
             <th width="30%">Percentile (lowest to highest)</th>
         </tr>
         </thead>

--- a/yeastphenome/apps/datasets/templates/datasets/dataset_similarity_explorer.html
+++ b/yeastphenome/apps/datasets/templates/datasets/dataset_similarity_explorer.html
@@ -103,7 +103,7 @@
     </div>
 </div>
 
-
+{% if dataset.data_source.release == True  %}
 {% if datasets %}<div class="row" style="padding-top:20px" id='similar'>
     <div class="col-md-12">
     <table id="dataset_table" class="tablesorter table table-striped" width="100%">
@@ -123,7 +123,7 @@
     <a href="{% url 'datasets:download_dataset_similarities' dataset.id %}"><button type="button"class="btn btn-info" type="button">Download all</button></a>
   </div>
 </div>{% endif %}
-
+{% endif %}
 {% endblock %}
 {% block scripts %}
 <script src="{% static 'js/typeahead.bundle.js' %}"></script>

--- a/yeastphenome/apps/datasets/templates/datasets/detail.html
+++ b/yeastphenome/apps/datasets/templates/datasets/detail.html
@@ -65,6 +65,7 @@
     </div>
 </div>
 
+    {% if dataset.data_source.release == True %}
 {% if datasets_top or datasets_bottom %}
 <div class="row" style="padding-top:30px" id='datasets'>
     <div class="col-md-12">
@@ -122,6 +123,7 @@
         </div>
     </div>
 </div>{% endif %}
+    {%  endif %}
 
 
 {% endblock %}

--- a/yeastphenome/apps/datasets/templates/datasets/plot.html
+++ b/yeastphenome/apps/datasets/templates/datasets/plot.html
@@ -4,6 +4,7 @@
 {% load humanize %}
 {% block title %}{{ object }} / Datasets / Papers / {{ SITE_NAME }}{% endblock %}
 {% block content %}
+    {%  if dataset.data_source.release == True %}
 <div class="row" style="padding-bottom:35px">
     <div class="col-md-12">
         <h1>Phenotypic Scores for {{ dataset.name }}</h1>
@@ -15,7 +16,7 @@
        {% include "graphs/dataset-genes/index.html" with hide_title="yes" %}
     </div>
 </div>
-
+    {%  endif %}
 {% endblock %}
 {% block scripts %}
 {% include "scripts/script_popup.html" %}


### PR DESCRIPTION
Sorry for one last minute update. For a handful of datasets (which I received directly from the authors) I am still waiting for explicit permission to release. Download is already disabled for these but viewing was still on. I just added a couple of if-statements to the templates to hide these data for now. It literally affects 2-3 papers at most. Could we merge this in before official release 1?