### PR TITLE
tags to phenotypes table, genealias non null, and schemaorg update

### DIFF
--- a/yeastphenome/apps/api/phenotypes.py
+++ b/yeastphenome/apps/api/phenotypes.py
@@ -86,6 +86,8 @@ class RunPhenotypesQuery(RatelimitMixin, APIView):
             "2desc": "-reporter_list",
             "3asc": "paper_list",
             "3desc": "-paper_list",
+            "4asc": "tags_list",
+            "4desc": "-tags_list",
         }
 
         # Empty datatable
@@ -111,6 +113,13 @@ class RunPhenotypesQuery(RatelimitMixin, APIView):
             agg_field = "phenotype__reporter"
             queryset = queryset.annotate(
                 reporter_list=StringAgg(
+                    agg_field, delimiter="; ", distinct=True, ordering=agg_field
+                )
+            )
+
+            agg_field = "tags__name"
+            queryset = queryset.annotate(
+                tags_list=StringAgg(
                     agg_field, delimiter="; ", distinct=True, ordering=agg_field
                 )
             )
@@ -153,6 +162,7 @@ class RunPhenotypesQuery(RatelimitMixin, APIView):
                     condition_list,
                     join_and_more(observable.reporter_list.split("; "), 7),
                     join_and_more(observable.paper_list.split("; "), 7),
+                    join_and_more(observable.tags_list.split("; "), 7),
                 ]
             )
 

--- a/yeastphenome/apps/datasets/templates/datasets/schemaorg_dataset.html
+++ b/yeastphenome/apps/datasets/templates/datasets/schemaorg_dataset.html
@@ -23,7 +23,7 @@
         "contentUrl":"{{ DOMAIN }}/datasets/download/?{{ dataset.id }}=on"
      }],{% endif %}
     "datePublished": "{{ dataset.paper.pub_date }}",
-    "dateModified": "{{ dataset.paper.modified_on |date:"c" }}",
+    "dateModified": "{{ dataset.data_modified_on |date:"c" }}",
     "description": "Phenotypic screen of the yeast knock-out collection.\n{% if dataset.collection %}Collection type: {{ dataset.collection.name }}\n{% endif %}Number of tested strains: {{ dataset.tested_num }}\n{% if dataset.phenotype %}Phenotype: {{ dataset.phenotype.name }}\n{% endif %}{% if dataset.conditionset %}Experimental condition: {{ dataset.conditionset.systematic_name }}\n{% endif %}{% if dataset.medium %}Medium: {{ dataset.medium.common_name }}\n{% endif %} Type of data: {{ dataset.data_measured.name }}\n",
     "url": "{{ DOMAIN }}/datasets/{{ dataset.id }}/",
     "identifier": []

--- a/yeastphenome/apps/genes/models.py
+++ b/yeastphenome/apps/genes/models.py
@@ -9,7 +9,7 @@ from django.urls import reverse
 class GeneAlias(models.Model):
     """A GeneAlias is another name for a gene"""
 
-    name = models.CharField(max_length=250, null=True, blank=True, unique=True)
+    name = models.CharField(max_length=250, null=False, blank=False, unique=True)
 
     @classmethod
     def all_valid(cls):

--- a/yeastphenome/apps/phenotypes/search.py
+++ b/yeastphenome/apps/phenotypes/search.py
@@ -39,8 +39,6 @@ def run_search_tag_query(queries):
             Q(name__iregex=query)
             | Q(tags__name__iregex=query)
             | Q(phenotype__name__iregex=query)
-            # | Q(phenotype__description__iregex=query)
-            # | Q(phenotype__measurement__name__iregex=query)
             | Q(phenotype__reporter__iregex=query)
         )
         queryset = queryset.filter(f)

--- a/yeastphenome/apps/phenotypes/templates/phenotypes/phenotypes_table.html
+++ b/yeastphenome/apps/phenotypes/templates/phenotypes/phenotypes_table.html
@@ -8,6 +8,7 @@
                 <th>Conditions</th>
                 <th>Reporters</th>
                 <th>Papers</th>
+                <th>Tags</th>
             </tr>
             </thead><tbody id="papersTableBody">
         {% for observable in observables %}<tr>


### PR DESCRIPTION
Here are a few quick changes to finish up #86, including:

 - #124 which makes the field non null
 - #114 updates the dataset modified field to use data_modified_on
 - #104 adding a list of tags to the phenotype explorer page

For the last, there is a tag list function provided by the model, but using it makes the order strange again, so instead I used the same approach to create an aggregated field for `tags_list`.

Signed-off-by: vsoch <vsochat@stanford.edu>