### PR TITLE
Add/gene scatterplot

### DIFF
--- a/yeastphenome/apps/datasets/models.py
+++ b/yeastphenome/apps/datasets/models.py
@@ -357,6 +357,8 @@ class DatasetSimilarity(models.Model):
         Dataset, on_delete=models.CASCADE, related_name="dataset_similarity2"
     )
     score = models.DecimalField(max_digits=10, decimal_places=3)
+
+    # IMPORTANT: this is actually a standard deviation
     pvalue = models.DecimalField(max_digits=10, decimal_places=6)
 
     @classmethod

--- a/yeastphenome/apps/genes/models.py
+++ b/yeastphenome/apps/genes/models.py
@@ -94,6 +94,7 @@ class GeneSimilarity(models.Model):
     score = models.DecimalField(
         max_digits=10, decimal_places=3, help_text="z-score of the metric."
     )
+    # IMPORTANT: this is actually a standard deviation
     pvalue = models.DecimalField(max_digits=10, decimal_places=6)
 
     @classmethod

--- a/yeastphenome/apps/genes/templates/genes/similar_genes.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_genes.html
@@ -62,12 +62,13 @@ tr.highlight {
                 <table id="similar_table" class="tablesorter table table-striped" width="100%">
                     <thead>
                     <tr>
-                        <th style="text-align:left" data-placeholder="Select an name" class="text-nowrap" width="25%">
+                        <th style="text-align:left" data-placeholder="Select an name" class="text-nowrap" width="20%">
                             Gene
                         </th>
-                        <th style="text-align:left" width="25%">Correlation Mean</th>
-                        <th style="text-align:left" width="25%">Correlation Std. Dev.</th>
-                        <th style="text-align:left" width="25%">Percentile (lowest to highest)</th>
+                        <th style="text-align:left" width="20%">Correlation Mean</th>
+                        <th style="text-align:left" width="20%">Correlation Std. Dev.</th>
+                        <th style="text-align:left" width="20%">Percentile (lowest to highest)</th>
+                        <th width="20%">Compare</th>
                     </tr>
                     </thead>
                     <tbody id="similar_table_body">
@@ -77,6 +78,7 @@ tr.highlight {
                             <td class="dt-center">{{ sim.score|stringformat:".2f" }}</td>
                             <td class="dt-center">{{ sim.pvalue|stringformat:".2f" }}</td>
                             <td class="dt-center">{{ ranks|lookup:forloop.counter0|floatformat:1 }}%</td>
+                            <td class="dt-center"><a href="{% url 'genes:similar_scatterplot' sim.gene1.id sim.gene2.id %}">Scatter plot</a></td>
                         </tr>
                     {% endfor %}
                 </table>

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -22,10 +22,17 @@
   height: 28px;
   pointer-events: none;
 }
+
+.regression {
+  stroke-width: 1px;
+  stroke: {% if sim.score > 0 %}green{% else %}darkred{% endif %};
+  stroke-dasharray: 10,5;
+}
 </style>
 <div class="row">
     <div class="col-md-12">
         <h1>Gene Similarity Scatterplot: {{ gene1 }} vs. {{ gene2 }}</h1>
+        <p>Correlation: {{ sim.score }}</p> 
         <div id="gene_plot"></div>
     </div>
 </div>
@@ -70,6 +77,8 @@ var tooltip = d3.select("body").append("div")
     .attr("class", "tooltip")
     .style("opacity", 0);
 
+
+var lg = calcLinear(data, "value1", "value2");
 
 // don't want dots overlapping axis, so add in buffer to data domain
 xScale.domain([d3.min(data, xValue)-1, d3.max(data, xValue)+1]);
@@ -127,6 +136,13 @@ svg.selectAll(".dot")
                .style("opacity", 0);
       });
 
+svg.append("line")
+    .attr("class", "regression")
+    .attr("x1", xScale(lg.ptA.x))
+    .attr("y1", yScale(lg.ptA.y))
+    .attr("x2", xScale(lg.ptB.x))
+    .attr("y2", yScale(lg.ptB.y));
+
 // draw legend
 // var legend = svg.selectAll(".legend")
 //      .data(color.domain())
@@ -148,5 +164,77 @@ svg.selectAll(".dot")
 //      .attr("dy", ".35em")
 //      .style("text-anchor", "end")
 //      .text(function(d) { return d;})
+
+
+// https://bl.ocks.org/HarryStevens/be559bed98d662f69e68fc8a7e0ad097
+function calcLinear(data, x, y){
+
+      // Get boundaries
+      var minX = d3.min(data, function(d){ return d.value1})
+      var minY = d3.min(data, function(d){ return d.value2})
+      var maxX = d3.max(data, function(d){ return d.value1})
+      var maxY = d3.max(data, function(d){ return d.value2})
+
+      // Let n = the number of data points
+      var n = data.length;
+
+      // Get just the points
+      var pts = [];
+      data.forEach(function(d,i){
+        var obj = {};
+        obj.x = d[x];
+        obj.y = d[y];
+        obj.mult = obj.x*obj.y;
+        pts.push(obj);
+      });
+      console.log(pts)
+
+      // Let a equal n times the summation of all x-values multiplied by their corresponding y-values
+      // Let b equal the sum of all x-values times the sum of all y-values
+      // Let c equal n times the sum of all squared x-values
+      // Let d equal the squared sum of all x-values
+      var sum = 0;
+      var xSum = 0;
+      var ySum = 0;
+      var sumSq = 0;
+      pts.forEach(function(pt){
+        sum = sum + pt.mult;
+        xSum = xSum + pt.x;
+        ySum = ySum + pt.y;
+        sumSq = sumSq + (pt.x * pt.x);
+      });
+      var a = sum * n;
+      var b = xSum * ySum;
+      var c = sumSq * n;
+      var d = xSum * xSum;
+
+      // Plug the values that you calculated for a, b, c, and d into the following equation to calculate the slope
+      // slope = m = (a - b) / (c - d)
+      var m = (a - b) / (c - d);
+
+      // Intercept: Let e equal the sum of all y-values
+      var e = ySum;
+
+      // Let f equal the slope times the sum of all x-values
+      var f = m * xSum;
+
+      // Plug the values you have calculated for e and f into the following equation for the y-intercept
+      // y-intercept = b = (e - f) / n
+      var b = (e - f) / n;
+
+      // return an object of two points
+      // each point is an object with an x and y coordinate
+      return {
+        ptA : {
+          x: minX,
+          y: m * minX + b
+        },
+        ptB : {
+          x: maxX,
+          y: m * maxX + b
+        }
+  }
+}
+
 </script>
 {% endblock %}

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -51,7 +51,7 @@
 
 <script>
 
-var data = [{% for dataset_id, entry in scores.items %}{"dataset_id": {{ dataset_id }}, "dataset_name": "{{ entry.dataset_name }}", "value1": {{ entry.values.0|stringformat:".2f" }}, "value2": {{ entry.values.1|stringformat:".2f" }}, "gene1_id": {{ entry.genes.0 }}, "gene2_id": {{ entry.genes.1 }}, "gene1": "{{ entry.names.0 }}", "gene2": "{{ entry.names.1 }}" }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
+var data = [{% for idx, entry in scores.items %}{"dataset_id": {{ entry.dataset_id }}, "dataset_name": "{{ entry.name }}", "value1": {{ entry.valuez_x|stringformat:".2f" }}, "value2": {{ entry.valuez_y|stringformat:".2f" }} }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
 
 var margin = {top: 20, right: 20, bottom: 30, left: 40},
     width = 700 - margin.left - margin.right,

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -1,7 +1,7 @@
 {% extends "base/wide.html" %}
 {% load static %}
 {% load my_filters %}
-{% block title %}Phenotypic Scores / {{ SITE_NAME }}{% endblock %}
+{% block title %}Genes similar to: {{ gene1 }} vs. {{ gene2 }} / {{ SITE_NAME }}{% endblock %}
 {% block content %}
 <style>
 .axis path,
@@ -13,12 +13,17 @@
 
 .dot {
   cursor: pointer;
+  opacity: 50%;
 }
 
 .tooltip {
   position: absolute;
-  width: 300px;
-  height: 28px;
+  width: 350px;
+  padding: 5px;
+  height: 80px;
+  border-radius: 5px;
+  background-color: white;
+  opacity: 80%;
   pointer-events: none;
 }
 
@@ -34,8 +39,8 @@
 </style>
 <div class="row">
     <div class="col-md-12">
-        <h1>Phenotypic Scores: {{ gene1 }} vs. {{ gene2 }}</h1>
-        <p>Correlation: {{ sim.score|stringformat:".2f" }}</p> 
+        <h1>Genes similar to: {{ gene1 }} vs. {{ gene2 }}</h1>
+        <p>Correlation: {{ sim.score|stringformat:".2f" }} +/- {{ sim.pvalue|stringformat:".2f" }}</p> 
         <div id="gene_plot"></div>
     </div>
 </div>
@@ -49,7 +54,7 @@
 var data = [{% for dataset_id, entry in scores.items %}{"dataset_id": {{ dataset_id }}, "dataset_name": "{{ entry.dataset_name }}", "value1": {{ entry.values.0|stringformat:".2f" }}, "value2": {{ entry.values.1|stringformat:".2f" }}, "gene1_id": {{ entry.genes.0 }}, "gene2_id": {{ entry.genes.1 }}, "gene1": "{{ entry.names.0 }}", "gene2": "{{ entry.names.1 }}" }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
 
 var margin = {top: 20, right: 20, bottom: 30, left: 40},
-    width = 1400 - margin.left - margin.right,
+    width = 700 - margin.left - margin.right,
     height = 700 - margin.top - margin.bottom;
 
 // setup x 
@@ -80,12 +85,27 @@ var tooltip = d3.select("body").append("div")
     .attr("class", "tooltip")
     .style("opacity", 0);
 
+// The plot should be square
+var minX = d3.min(data, function(d){ return d.value1})
+var maxX = d3.max(data, function(d){ return d.value1})
+var minY = d3.min(data, function(d){ return d.value2})
+var maxY = d3.max(data, function(d){ return d.value2})
 
-var lg = addXY(data);
+lowerBound = minY
+if (minX < minY) {
+    lowerBound = minX
+}
+
+upperBound = maxY
+if (maxX > maxY) {
+    upperBound = maxX
+}
 
 // don't want dots overlapping axis, so add in buffer to data domain
-xScale.domain([d3.min(data, xValue)-1, d3.max(data, xValue)+1]);
-yScale.domain([d3.min(data, yValue)-1, d3.max(data, yValue)+1]);
+xScale.domain([lowerBound -1, upperBound +1]);
+yScale.domain([lowerBound -1, upperBound +1]);
+
+var lg = addXY(lowerBound, upperBound);
 
 // x-axis
 svg.append("g")
@@ -116,7 +136,7 @@ svg.selectAll(".dot")
       .data(data)
     .enter().append("circle")
       .attr("class", "dot")
-      .attr("r", 3)
+      .attr("r", 5)
       .attr("cx", xMap)
       .attr("cy", yMap)
       .style("fill", function(d) { return "steelblue";}) 
@@ -147,10 +167,10 @@ svg.append("line")
     .attr("y2", yScale(lg.ptB.y));
 
 svg.append('text')
-    .attr('x', xScale(lg.ptA.x + 1))
-    .attr('y', yScale(lg.ptA.y))
+    .attr('x', xScale(lg.ptB.x))
+    .attr('y', yScale(lg.ptB.y))
     .attr('dy', '1em')
-    .attr('text-anchor', 'end')
+    .attr('text-anchor', 'middle')
     .text("y = x")
     .style("fill", "darkred")
 
@@ -177,33 +197,17 @@ svg.append('text')
 //      .text(function(d) { return d;})
 
 
-function addXY(data){
-
-      // Get boundaries
-      var minX = d3.min(data, function(d){ return d.value1})
-      var maxX = d3.max(data, function(d){ return d.value1})
-      var minY = d3.min(data, function(d){ return d.value2})
-      var maxY = d3.max(data, function(d){ return d.value2})
-
-      lowerBound = minY
-      if (minX > minY) {
-          lowerBound = minX
-      }
-
-      upperBound = maxY
-      if (maxX < maxY) {
-          upperBound = maxX
-      }
+function addXY(lowerBound, upperBound){
 
       // return an object of two points for y=x within the plot area
       return {
         ptA : {
-          x: lowerBound,
-          y: lowerBound
+          x: lowerBound -1,
+          y: lowerBound -1
         },
         ptB : {
-          x: upperBound,
-          y: upperBound
+          x: upperBound +1,
+          y: upperBound +1
         }
   }
 }

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -1,7 +1,7 @@
 {% extends "base/wide.html" %}
 {% load static %}
 {% load my_filters %}
-{% block title %}Genes similar to: {{ gene1 }} vs. {{ gene2 }} / {{ SITE_NAME }}{% endblock %}
+{% block title %}Genes similar to {{ gene1 }}: {{ gene2 }} / {{ SITE_NAME }}{% endblock %}
 {% block content %}
 <style>
 .axis path,
@@ -39,7 +39,7 @@
 </style>
 <div class="row">
     <div class="col-md-12">
-        <h1>Genes similar to: {{ gene1 }} vs. {{ gene2 }}</h1>
+        <h1>Genes similar to {{ gene1 }}: {{ gene2 }}</h1>
         <p>Correlation: {{ sim.score|stringformat:".2f" }} +/- {{ sim.pvalue|stringformat:".2f" }}</p> 
         <div id="gene_plot"></div>
     </div>

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -1,0 +1,152 @@
+{% extends "base/wide.html" %}
+{% load static %}
+{% load my_filters %}
+{% block title %}Similar Genes / {{ SITE_NAME }}{% endblock %}
+{% block content %}
+<style>
+.axis path,
+.axis line {
+  fill: none;
+  stroke: #000;
+  shape-rendering: crispEdges;
+}
+
+.dot {
+  stroke: darkblue;
+  cursor: pointer;
+}
+
+.tooltip {
+  position: absolute;
+  width: 300px;
+  height: 28px;
+  pointer-events: none;
+}
+</style>
+<div class="row">
+    <div class="col-md-12">
+        <h1>Gene Similarity Scatterplot: {{ gene1 }} vs. {{ gene2 }}</h1>
+        <div id="gene_plot"></div>
+    </div>
+</div>
+{% endblock %}
+{% block scripts %}
+
+<script src="https://d3js.org/d3.v3.min.js"></script>
+
+<script>
+
+var data = [{% for dataset_id, entry in scores.items %}{"dataset_id": {{ dataset_id }}, "value1": {{ entry.values.0|stringformat:".2f" }}, "value2": {{ entry.values.1|stringformat:".2f" }}, "gene1_id": {{ entry.genes.0 }}, "gene2_id": {{ entry.genes.1 }}, "gene1": "{{ entry.names.0 }}", "gene2": "{{ entry.names.1 }}" }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
+
+var margin = {top: 20, right: 20, bottom: 30, left: 40},
+    width = 1400 - margin.left - margin.right,
+    height = 700 - margin.top - margin.bottom;
+
+// setup x 
+var xValue = function(d) { return d.value1;}, // data -> value
+    xScale = d3.scale.linear().range([0, width]), // value -> display
+    xMap = function(d) { return xScale(xValue(d));}, // data -> display
+    xAxis = d3.svg.axis().scale(xScale).orient("bottom");
+
+// setup y
+var yValue = function(d) { return d.value2;}, // data -> value
+    yScale = d3.scale.linear().range([height, 0]), // value -> display
+    yMap = function(d) { return yScale(yValue(d));}, // data -> display
+    yAxis = d3.svg.axis().scale(yScale).orient("left");
+
+// setup fill color (this could be more meaningful, how to group datasets?)
+var cValue = function(d) { return d.dataset_id;},
+    color = d3.scale.category10();
+
+// add the graph canvas to the body of the webpage
+var svg = d3.select("#gene_plot").append("svg")
+    .attr("width", width + margin.left + margin.right)
+    .attr("height", height + margin.top + margin.bottom)
+  .append("g")
+    .attr("transform", "translate(" + margin.left + "," + margin.top + ")");
+
+// add the tooltip area to the webpage
+var tooltip = d3.select("body").append("div")
+    .attr("class", "tooltip")
+    .style("opacity", 0);
+
+
+// don't want dots overlapping axis, so add in buffer to data domain
+xScale.domain([d3.min(data, xValue)-1, d3.max(data, xValue)+1]);
+yScale.domain([d3.min(data, yValue)-1, d3.max(data, yValue)+1]);
+
+// x-axis
+svg.append("g")
+      .attr("class", "x axis")
+      .attr("transform", "translate(0," + height + ")")
+      .call(xAxis)
+    .append("text")
+      .attr("class", "label")
+      .attr("x", width)
+      .attr("y", -6)
+      .style("text-anchor", "end")
+      .text("{{ gene1 }}");
+
+// y-axis
+svg.append("g")
+      .attr("class", "y axis")
+      .call(yAxis)
+    .append("text")
+      .attr("class", "label")
+      .attr("transform", "rotate(-90)")
+      .attr("y", 6)
+      .attr("dy", ".71em")
+      .style("text-anchor", "end")
+      .text("{{ gene2 }}");
+
+// draw dots
+svg.selectAll(".dot")
+      .data(data)
+    .enter().append("circle")
+      .attr("class", "dot")
+      .attr("r", 3)
+      .attr("cx", xMap)
+      .attr("cy", yMap)
+      .style("fill", function(d) { return "steelblue";}) 
+//      .style("fill", function(d) { return color(cValue(d));}) 
+      .on("click", function(d) {
+         document.location = "/datasets/" + d.dataset_id + "/";
+      })
+      .on("mouseover", function(d) {
+          tooltip.transition()
+               .duration(200)
+               .style("opacity", .9);
+          tooltip.html("Dataset: " + d.dataset_id + " <br/> (" + xValue(d) 
+	        + ", " + yValue(d) + ")")
+               .style("left", (d3.event.pageX + 5) + "px")
+               .style("top", (d3.event.pageY - 28) + "px");
+      })
+      .on("mouseout", function(d) {
+          tooltip.transition()
+               .duration(500)
+               .style("opacity", 0);
+      });
+
+// draw legend
+// var legend = svg.selectAll(".legend")
+//      .data(color.domain())
+//    .enter().append("g")
+//      .attr("class", "legend")
+//      .attr("transform", function(d, i) { return "translate(0," + i * 20 + ")"; });
+
+// draw legend colored rectangles
+//  legend.append("rect")
+//      .attr("x", width - 18)
+//      .attr("width", 18)
+//      .attr("height", 18)
+//      .style("fill", color);
+
+// draw legend text
+//  legend.append("text")
+//      .attr("x", width - 24)
+//      .attr("y", 9)
+//      .attr("dy", ".35em")
+//      .style("text-anchor", "end")
+//      .text(function(d) { return d;})
+</script>
+{% endblock %}

--- a/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_scatterplot.html
@@ -1,7 +1,7 @@
 {% extends "base/wide.html" %}
 {% load static %}
 {% load my_filters %}
-{% block title %}Similar Genes / {{ SITE_NAME }}{% endblock %}
+{% block title %}Phenotypic Scores / {{ SITE_NAME }}{% endblock %}
 {% block content %}
 <style>
 .axis path,
@@ -12,7 +12,6 @@
 }
 
 .dot {
-  stroke: darkblue;
   cursor: pointer;
 }
 
@@ -23,16 +22,20 @@
   pointer-events: none;
 }
 
-.regression {
+.xyline-text {
+ color: darkred !important;
+}
+
+.xyline {
   stroke-width: 1px;
-  stroke: {% if sim.score > 0 %}green{% else %}darkred{% endif %};
+  stroke: darkred;
   stroke-dasharray: 10,5;
 }
 </style>
 <div class="row">
     <div class="col-md-12">
-        <h1>Gene Similarity Scatterplot: {{ gene1 }} vs. {{ gene2 }}</h1>
-        <p>Correlation: {{ sim.score }}</p> 
+        <h1>Phenotypic Scores: {{ gene1 }} vs. {{ gene2 }}</h1>
+        <p>Correlation: {{ sim.score|stringformat:".2f" }}</p> 
         <div id="gene_plot"></div>
     </div>
 </div>
@@ -43,7 +46,7 @@
 
 <script>
 
-var data = [{% for dataset_id, entry in scores.items %}{"dataset_id": {{ dataset_id }}, "value1": {{ entry.values.0|stringformat:".2f" }}, "value2": {{ entry.values.1|stringformat:".2f" }}, "gene1_id": {{ entry.genes.0 }}, "gene2_id": {{ entry.genes.1 }}, "gene1": "{{ entry.names.0 }}", "gene2": "{{ entry.names.1 }}" }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
+var data = [{% for dataset_id, entry in scores.items %}{"dataset_id": {{ dataset_id }}, "dataset_name": "{{ entry.dataset_name }}", "value1": {{ entry.values.0|stringformat:".2f" }}, "value2": {{ entry.values.1|stringformat:".2f" }}, "gene1_id": {{ entry.genes.0 }}, "gene2_id": {{ entry.genes.1 }}, "gene1": "{{ entry.names.0 }}", "gene2": "{{ entry.names.1 }}" }{% if forloop.last %}{% else %},{% endif %}{% endfor %}]
 
 var margin = {top: 20, right: 20, bottom: 30, left: 40},
     width = 1400 - margin.left - margin.right,
@@ -78,7 +81,7 @@ var tooltip = d3.select("body").append("div")
     .style("opacity", 0);
 
 
-var lg = calcLinear(data, "value1", "value2");
+var lg = addXY(data);
 
 // don't want dots overlapping axis, so add in buffer to data domain
 xScale.domain([d3.min(data, xValue)-1, d3.max(data, xValue)+1]);
@@ -125,7 +128,7 @@ svg.selectAll(".dot")
           tooltip.transition()
                .duration(200)
                .style("opacity", .9);
-          tooltip.html("Dataset: " + d.dataset_id + " <br/> (" + xValue(d) 
+          tooltip.html("Dataset: " + d.dataset_name + " <br/> (" + xValue(d) 
 	        + ", " + yValue(d) + ")")
                .style("left", (d3.event.pageX + 5) + "px")
                .style("top", (d3.event.pageY - 28) + "px");
@@ -137,11 +140,19 @@ svg.selectAll(".dot")
       });
 
 svg.append("line")
-    .attr("class", "regression")
+    .attr("class", "xyline")
     .attr("x1", xScale(lg.ptA.x))
     .attr("y1", yScale(lg.ptA.y))
     .attr("x2", xScale(lg.ptB.x))
     .attr("y2", yScale(lg.ptB.y));
+
+svg.append('text')
+    .attr('x', xScale(lg.ptA.x + 1))
+    .attr('y', yScale(lg.ptA.y))
+    .attr('dy', '1em')
+    .attr('text-anchor', 'end')
+    .text("y = x")
+    .style("fill", "darkred")
 
 // draw legend
 // var legend = svg.selectAll(".legend")
@@ -166,72 +177,33 @@ svg.append("line")
 //      .text(function(d) { return d;})
 
 
-// https://bl.ocks.org/HarryStevens/be559bed98d662f69e68fc8a7e0ad097
-function calcLinear(data, x, y){
+function addXY(data){
 
       // Get boundaries
       var minX = d3.min(data, function(d){ return d.value1})
-      var minY = d3.min(data, function(d){ return d.value2})
       var maxX = d3.max(data, function(d){ return d.value1})
+      var minY = d3.min(data, function(d){ return d.value2})
       var maxY = d3.max(data, function(d){ return d.value2})
 
-      // Let n = the number of data points
-      var n = data.length;
+      lowerBound = minY
+      if (minX > minY) {
+          lowerBound = minX
+      }
 
-      // Get just the points
-      var pts = [];
-      data.forEach(function(d,i){
-        var obj = {};
-        obj.x = d[x];
-        obj.y = d[y];
-        obj.mult = obj.x*obj.y;
-        pts.push(obj);
-      });
-      console.log(pts)
+      upperBound = maxY
+      if (maxX < maxY) {
+          upperBound = maxX
+      }
 
-      // Let a equal n times the summation of all x-values multiplied by their corresponding y-values
-      // Let b equal the sum of all x-values times the sum of all y-values
-      // Let c equal n times the sum of all squared x-values
-      // Let d equal the squared sum of all x-values
-      var sum = 0;
-      var xSum = 0;
-      var ySum = 0;
-      var sumSq = 0;
-      pts.forEach(function(pt){
-        sum = sum + pt.mult;
-        xSum = xSum + pt.x;
-        ySum = ySum + pt.y;
-        sumSq = sumSq + (pt.x * pt.x);
-      });
-      var a = sum * n;
-      var b = xSum * ySum;
-      var c = sumSq * n;
-      var d = xSum * xSum;
-
-      // Plug the values that you calculated for a, b, c, and d into the following equation to calculate the slope
-      // slope = m = (a - b) / (c - d)
-      var m = (a - b) / (c - d);
-
-      // Intercept: Let e equal the sum of all y-values
-      var e = ySum;
-
-      // Let f equal the slope times the sum of all x-values
-      var f = m * xSum;
-
-      // Plug the values you have calculated for e and f into the following equation for the y-intercept
-      // y-intercept = b = (e - f) / n
-      var b = (e - f) / n;
-
-      // return an object of two points
-      // each point is an object with an x and y coordinate
+      // return an object of two points for y=x within the plot area
       return {
         ptA : {
-          x: minX,
-          y: m * minX + b
+          x: lowerBound,
+          y: lowerBound
         },
         ptB : {
-          x: maxX,
-          y: m * maxX + b
+          x: upperBound,
+          y: upperBound
         }
   }
 }

--- a/yeastphenome/apps/genes/templates/genes/similar_table.html
+++ b/yeastphenome/apps/genes/templates/genes/similar_table.html
@@ -1,9 +1,10 @@
 <table id="{{ table_id }}" class="table table-condensed table-hover" width="100%">
     <thead>
     <tr>
-        <th class="text-nowrap" width="30%">Gene</th>
-        <th width="30%">Correlation Mean</th>
-        <th width="30%">Correlation Std. Dev.</th>
+        <th class="text-nowrap" width="25%">Gene</th>
+        <th width="25%">Correlation Mean</th>
+        <th width="25%">Correlation Std. Dev.</th>
+        <th width="25%">Compare</th>
     </tr>
     </thead>
     <tbody>
@@ -12,6 +13,7 @@
             <td class="dt-center"><a href="{% url 'genes:detail' sim.gene2.id %}">{{ sim.gene2 }}</a></td>
             <td class="dt-center">{{ sim.score|stringformat:".2f" }}</td>
             <td class="dt-center">{{ sim.pvalue|stringformat:".2f" }}</td>
+            <td class="dt-center"><a href="{% url 'genes:similar_scatterplot' sim.gene1.id sim.gene2.id %}">Scatter plot</a></td>
         </tr>
     {% endfor %}
 </table>

--- a/yeastphenome/apps/genes/templates/graphs/barplot.html
+++ b/yeastphenome/apps/genes/templates/graphs/barplot.html
@@ -16,7 +16,7 @@ function draw_table(names) {
         gene_name = gene_lookup[e].name || "Dataset id: " + e
         gene_pvalue = gene_lookup[e].pvalue || ""
         gene_rank = gene_lookup[e].rank || ""
-        content += "<tr id='tr-" + e + "'><td class='dt-center' id='td-" + e + "'><a href='/genes/"+ e + "'>" + gene_name + "</a></td><td class='dt-center'>" + gene_value + "</td><td class='dt-center'>" + gene_pvalue + "</td><td class='dt-center'>"+ gene_rank + "</td></tr>\n"
+        content += "<tr id='tr-" + e + "'><td class='dt-center' id='td-" + e + "'><a href='/genes/"+ e + "'>" + gene_name + "</a></td><td class='dt-center'>" + gene_value + "</td><td class='dt-center'>" + gene_pvalue + "</td><td class='dt-center'>"+ gene_rank + "</td><td class='dt-center'><a href='/genes/{{ gene.id }}/similar/scatterplot/" + e + "/'>Scatter plot</a></td></tr>\n"
     })
 
     $("#similar_table_body").html(content)

--- a/yeastphenome/apps/genes/templates/graphs/barplot.html
+++ b/yeastphenome/apps/genes/templates/graphs/barplot.html
@@ -16,7 +16,7 @@ function draw_table(names) {
         gene_name = gene_lookup[e].name || "Dataset id: " + e
         gene_pvalue = gene_lookup[e].pvalue || ""
         gene_rank = gene_lookup[e].rank || ""
-        content += "<tr id='tr-" + e + "'><td class='dt-center' id='td-" + e + "'><a href='/genes/"+ e + "'>" + gene_name + "</a></td><td class='dt-center'>" + gene_value + "</td><td class='dt-center'>" + gene_pvalue + "</td><td class='dt-center'>"+ gene_rank + "</td><td class='dt-center'><a href='/genes/{{ gene.id }}/similar/scatterplot/" + e + "/'>Scatter plot</a></td></tr>\n"
+        content += "<tr id='tr-" + e + "'><td class='dt-center' id='td-" + e + "'><a href='/genes/"+ e + "'>" + gene_name + "</a></td><td class='dt-center'>" + gene_value + "</td><td class='dt-center'>" + gene_pvalue + "</td><td class='dt-center'>"+ gene_rank + "</td><td class='dt-center'><a href='/genes/{{ gene.id }}/similar/" + e + "/'>Scatter plot</a></td></tr>\n"
     })
 
     $("#similar_table_body").html(content)

--- a/yeastphenome/apps/genes/urls.py
+++ b/yeastphenome/apps/genes/urls.py
@@ -6,7 +6,7 @@ urlpatterns = [
     path("<int:gene_id>/", views.gene_detail, name="detail"),
     path("<int:gene_id>/similar/", views.similar_genes, name="similar_genes"),
     path(
-        "<int:gene1_id>/similar/scatterplot/<int:gene2_id>/",
+        "<int:gene1_id>/similar/<int:gene2_id>/",
         views.similar_scatterplot,
         name="similar_scatterplot",
     ),

--- a/yeastphenome/apps/genes/urls.py
+++ b/yeastphenome/apps/genes/urls.py
@@ -5,7 +5,11 @@ urlpatterns = [
     path("", views.gene_explorer, name="index"),
     path("<int:gene_id>/", views.gene_detail, name="detail"),
     path("<int:gene_id>/similar/", views.similar_genes, name="similar_genes"),
-    #    path("<int:gene_id>/similar/scatterplot/", views.similar_scatterplot, name="similar_scatterplot"),
+    path(
+        "<int:gene1_id>/similar/scatterplot/<int:gene2_id>/",
+        views.similar_scatterplot,
+        name="similar_scatterplot",
+    ),
     path(
         "<int:gene_id>/similar/download/",
         views.download_gene_similarities,

--- a/yeastphenome/apps/genes/views.py
+++ b/yeastphenome/apps/genes/views.py
@@ -117,12 +117,12 @@ def similar_scatterplot(request, gene1_id, gene2_id):
             "name": "%s" % gene1,
         },
         {
-            "url": reverse("genes:detail", args=[gene2.id]),
-            "name": "%s" % gene2,
+            "url": reverse("genes:similar_genes", args=[gene1.id]),
+            "name": "Similar Genes",
         },
         {
             "url": reverse("genes:similar_scatterplot", args=[gene1.id, gene2.id]),
-            "name": "Phenotypic Scores",
+            "name": "%s" % gene2,
         },
     ]
 

--- a/yeastphenome/apps/genes/views.py
+++ b/yeastphenome/apps/genes/views.py
@@ -6,7 +6,7 @@ from django.contrib import messages
 from django.db.models import Q
 
 from yeastphenome.apps.datasets.models import Data
-from yeastphenome.apps.genes.models import Gene
+from yeastphenome.apps.genes.models import Gene, GeneSimilarity
 from yeastphenome.apps.genes.search import get_search_tags
 from ratelimit.decorators import ratelimit
 from yeastphenome.settings import (
@@ -103,6 +103,12 @@ def similar_scatterplot(request, gene1_id, gene2_id):
     gene1 = get_object_or_404(Gene, pk=gene1_id)
     gene2 = get_object_or_404(Gene, pk=gene2_id)
 
+    # Get the correlation to add
+    sim = GeneSimilarity.objects.filter(
+        Q(gene1=gene1, gene2=gene2) | Q(gene1=gene2, gene2=gene1)
+    )
+    print(sim)
+
     # links are based on the page the user came from (e.g., the gene 1 should be correct)
     links = [
         {"url": reverse("common:explorer"), "name": "Explore data"},
@@ -153,11 +159,11 @@ def similar_scatterplot(request, gene1_id, gene2_id):
         scores[value[0]]["genes"].append(value[1])
         scores[value[0]]["names"].append(names[value[1]])
 
-    print(scores)
     context = {
         "gene1": gene1,
         "gene2": gene2,
         "scores": scores,
+        "sim": sim.first(),
         "links": links,
         "active": "explorer",
     }

--- a/yeastphenome/apps/genes/views.py
+++ b/yeastphenome/apps/genes/views.py
@@ -107,9 +107,8 @@ def similar_scatterplot(request, gene1_id, gene2_id):
     sim = GeneSimilarity.objects.filter(
         Q(gene1=gene1, gene2=gene2) | Q(gene1=gene2, gene2=gene1)
     )
-    print(sim)
 
-    # links are based on the page the user came from (e.g., the gene 1 should be correct)
+    # Explore data > Genes > YHR045 / YHR045W > Similar genes > DAP1 / YPL170W
     links = [
         {"url": reverse("common:explorer"), "name": "Explore data"},
         {"url": reverse("genes:index"), "name": "Genes"},
@@ -118,8 +117,12 @@ def similar_scatterplot(request, gene1_id, gene2_id):
             "name": "%s" % gene1,
         },
         {
+            "url": reverse("genes:detail", args=[gene2.id]),
+            "name": "%s" % gene2,
+        },
+        {
             "url": reverse("genes:similar_scatterplot", args=[gene1.id, gene2.id]),
-            "name": "Gene Similarity Scatterplot",
+            "name": "Phenotypic Scores",
         },
     ]
 
@@ -147,14 +150,19 @@ def similar_scatterplot(request, gene1_id, gene2_id):
     data = Data.objects.filter(
         Q(dataset_id__in=shared), Q(gene_id__in=[gene1.id, gene2.id])
     )
-    values = data.values_list("dataset_id", "gene_id", "valuez")
+    values = data.values_list("dataset_id", "gene_id", "valuez", "dataset__name")
     scores = {}
 
     # Lookup looks like  15343: {'values': [Decimal('-0.97599'), Decimal('0.34786')], 'genes': [1, 3]},
     # Note that the gene ids are sorted least to greatest, so gene1 < gene2
     for value in values:
         if value[0] not in scores:
-            scores[value[0]] = {"values": [], "genes": [], "names": []}
+            scores[value[0]] = {
+                "values": [],
+                "genes": [],
+                "names": [],
+                "dataset_name": value[3],
+            }
         scores[value[0]]["values"].append(value[2])
         scores[value[0]]["genes"].append(value[1])
         scores[value[0]]["names"].append(names[value[1]])

--- a/yeastphenome/apps/genes/views.py
+++ b/yeastphenome/apps/genes/views.py
@@ -1,11 +1,11 @@
-from django.shortcuts import render, redirect
+from django.shortcuts import render
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, reverse
 from django.conf import settings
-from django.contrib import messages
 from django.db.models import Q
+import pandas
 
-from yeastphenome.apps.datasets.models import Data
+from yeastphenome.apps.datasets.models import Data, Dataset
 from yeastphenome.apps.genes.models import Gene, GeneSimilarity
 from yeastphenome.apps.genes.search import get_search_tags
 from ratelimit.decorators import ratelimit
@@ -108,6 +108,29 @@ def similar_scatterplot(request, gene1_id, gene2_id):
         Q(gene1=gene1, gene2=gene2) | Q(gene1=gene2, gene2=gene1)
     )
 
+    # Get data for gene1 and gene2 as pandas dataframes
+    data1 = pandas.DataFrame(list(Data.objects.filter(gene_id=gene1.id).values()))
+    data2 = pandas.DataFrame(list(Data.objects.filter(gene_id=gene2.id).values()))
+
+    # Join the 2 dataframes using dataset_id as the key
+    data = data1.merge(data2, on="dataset_id")
+
+    # Only keep rows where both genes have values (are not null)
+    data = data.loc[data["valuez_x"].notnull() & data["valuez_y"].notnull()]
+
+    # Get datasets names
+    datasets = pandas.DataFrame(
+        list(Dataset.objects.filter(id__in=data["dataset_id"].values).values())
+    )
+
+    # Add them to the data dataframe
+    data = data.merge(datasets[["id", "name"]], left_on="dataset_id", right_on="id")
+
+    # Convert to scores dictionary for view
+    scores = data[["dataset_id", "valuez_x", "valuez_y", "name"]].to_dict(
+        orient="index"
+    )
+
     # Explore data > Genes > YHR045 / YHR045W > Similar genes > DAP1 / YPL170W
     links = [
         {"url": reverse("common:explorer"), "name": "Explore data"},
@@ -125,47 +148,6 @@ def similar_scatterplot(request, gene1_id, gene2_id):
             "name": "%s" % gene2,
         },
     ]
-
-    # But we want to sort the genes by id so we can correctly assign the axes
-    # This means that gene1 should have the smaller id
-    if gene1.id > gene2.id:
-        gene1, gene2 = gene2, gene1
-    names = {gene.id: str(gene) for gene in [gene1, gene2]}
-
-    # We only want datasets with both genes defined
-    datasets1 = gene1.data_set.filter(valuez__isnull=False).values_list(
-        "dataset_id", flat=True
-    )
-    datasets2 = gene2.data_set.filter(valuez__isnull=False).values_list(
-        "dataset_id", flat=True
-    )
-    shared = set(datasets1).intersection(set(datasets2))
-
-    # Cut out early if there is no intersection
-    if not shared:
-        messages.info(request, "These datasets do not have any overlapping genes")
-        return redirect("genes:detail", args=[gene1.id])
-
-    # Get shared datasets, and create a lookup of scores based on dataset id
-    data = Data.objects.filter(
-        Q(dataset_id__in=shared), Q(gene_id__in=[gene1.id, gene2.id])
-    )
-    values = data.values_list("dataset_id", "gene_id", "valuez", "dataset__name")
-    scores = {}
-
-    # Lookup looks like  15343: {'values': [Decimal('-0.97599'), Decimal('0.34786')], 'genes': [1, 3]},
-    # Note that the gene ids are sorted least to greatest, so gene1 < gene2
-    for value in values:
-        if value[0] not in scores:
-            scores[value[0]] = {
-                "values": [],
-                "genes": [],
-                "names": [],
-                "dataset_name": value[3],
-            }
-        scores[value[0]]["values"].append(value[2])
-        scores[value[0]]["genes"].append(value[1])
-        scores[value[0]]["names"].append(names[value[1]])
 
     context = {
         "gene1": gene1,

--- a/yeastphenome/apps/genes/views.py
+++ b/yeastphenome/apps/genes/views.py
@@ -1,8 +1,11 @@
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404, reverse
 from django.conf import settings
+from django.contrib import messages
+from django.db.models import Q
 
+from yeastphenome.apps.datasets.models import Data
 from yeastphenome.apps.genes.models import Gene
 from yeastphenome.apps.genes.search import get_search_tags
 from ratelimit.decorators import ratelimit
@@ -89,6 +92,76 @@ def similar_genes(request, gene_id):
         "active": "explorer",
     }
     return render(request, "genes/similar_genes.html", context)
+
+
+@ratelimit(key="ip", rate=rl_rate, block=rl_block)
+def similar_scatterplot(request, gene1_id, gene2_id):
+    """Generate a scatterplot to compare two genes across datasets. You can
+    interchange gene1 and gene2 and they will produce the same plot (but switched
+    axes). This makes the view flexible to any combination of genes.
+    """
+    gene1 = get_object_or_404(Gene, pk=gene1_id)
+    gene2 = get_object_or_404(Gene, pk=gene2_id)
+
+    # links are based on the page the user came from (e.g., the gene 1 should be correct)
+    links = [
+        {"url": reverse("common:explorer"), "name": "Explore data"},
+        {"url": reverse("genes:index"), "name": "Genes"},
+        {
+            "url": reverse("genes:detail", args=[gene1.id]),
+            "name": "%s" % gene1,
+        },
+        {
+            "url": reverse("genes:similar_scatterplot", args=[gene1.id, gene2.id]),
+            "name": "Gene Similarity Scatterplot",
+        },
+    ]
+
+    # But we want to sort the genes by id so we can correctly assign the axes
+    # This means that gene1 should have the smaller id
+    if gene1.id > gene2.id:
+        gene1, gene2 = gene2, gene1
+    names = {gene.id: str(gene) for gene in [gene1, gene2]}
+
+    # We only want datasets with both genes defined
+    datasets1 = gene1.data_set.filter(valuez__isnull=False).values_list(
+        "dataset_id", flat=True
+    )
+    datasets2 = gene2.data_set.filter(valuez__isnull=False).values_list(
+        "dataset_id", flat=True
+    )
+    shared = set(datasets1).intersection(set(datasets2))
+
+    # Cut out early if there is no intersection
+    if not shared:
+        messages.info(request, "These datasets do not have any overlapping genes")
+        return redirect("genes:detail", args=[gene1.id])
+
+    # Get shared datasets, and create a lookup of scores based on dataset id
+    data = Data.objects.filter(
+        Q(dataset_id__in=shared), Q(gene_id__in=[gene1.id, gene2.id])
+    )
+    values = data.values_list("dataset_id", "gene_id", "valuez")
+    scores = {}
+
+    # Lookup looks like  15343: {'values': [Decimal('-0.97599'), Decimal('0.34786')], 'genes': [1, 3]},
+    # Note that the gene ids are sorted least to greatest, so gene1 < gene2
+    for value in values:
+        if value[0] not in scores:
+            scores[value[0]] = {"values": [], "genes": [], "names": []}
+        scores[value[0]]["values"].append(value[2])
+        scores[value[0]]["genes"].append(value[1])
+        scores[value[0]]["names"].append(names[value[1]])
+
+    print(scores)
+    context = {
+        "gene1": gene1,
+        "gene2": gene2,
+        "scores": scores,
+        "links": links,
+        "active": "explorer",
+    }
+    return render(request, "genes/similar_scatterplot.html", context)
 
 
 @ratelimit(key="ip", rate=rl_rate, block=rl_block)


### PR DESCRIPTION
This will add a scatterplot to compare two genes. The link for viewing a scatterplot appears in the truncated similarity tables on the gene detail page, along with the larger "View all" table. For any pair: 

- We show a regression line along with the correlation.
- Mousing over a point shows the dataset id and coordinate (corresponding to the scores)
- clicking on a coordinate goes to the dataset page

Deployed to staging.